### PR TITLE
Add units to `Logger#getRealTimestamp()` Javadoc

### DIFF
--- a/junction/core/src/org/littletonrobotics/junction/Logger.java
+++ b/junction/core/src/org/littletonrobotics/junction/Logger.java
@@ -212,7 +212,7 @@ public class Logger {
   }
 
   /**
-   * Returns the true FPGA timestamp, regardless of the timestamp used for
+   * Returns the true FPGA timestamp in seconds, regardless of the timestamp used for
    * logging. Useful for analyzing performance. DO NOT USE this method for any
    * logic which might need to be replayed.
    */


### PR DESCRIPTION
It's unclear what units this method returns, especially since `HALUtil.getFPGATime()` doesn't have a Javadoc attached to it.