### PR TITLE
Update to 2023 Athena toolchain

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   athena:
     name: Build for Athena
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: 'Checkout repository'
         uses: actions/checkout@v2
@@ -72,7 +72,7 @@ jobs:
       matrix:
         host:
           - {os: macos-latest, displayName: "macOS"}
-          - {os: ubuntu-latest, displayName: "Linux"}
+          - {os: ubuntu-22.04, displayName: "Linux"}
           - {os: windows-latest, displayName: "Windows"}
 
     name: Build for ${{ matrix.host.displayName }}

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -219,24 +219,24 @@ http_archive(
 http_archive(
     name = "athena_toolchain_linux_x64_files",
     build_file = "@//:build_tools/toolchain/athena_toolchain_linux_x64_files.BUILD",
-    sha256 = "b27cde302e46d11524aedf664129bc3ac7df02a78d0f9e4ab3f1feb40d667ab4",
-    urls = ["https://github.com/wpilibsuite/roborio-toolchain/releases/download/v2022-1/FRC-2022-Linux-Toolchain-7.3.0.tar.gz"],
+#    sha256 = "b27cde302e46d11524aedf664129bc3ac7df02a78d0f9e4ab3f1feb40d667ab4",
+    urls = ["https://github.com/wpilibsuite/opensdk/releases/download/v2023-5/cortexa9_vfpv3-roborio-academic-2023-x86_64-linux-gnu-Toolchain-12.1.0.tgz"],
 )
 
 # Same as above for win32 (also supports 64 bit)
 http_archive(
     name = "athena_toolchain_windows_x64_files",
     build_file = "@//:build_tools/toolchain/athena_toolchain_windows_x64_files.BUILD",
-    sha256 = "3a8815d9c715e7f0f5d2106e4f16282863a3ff63121d259703b281881daea683",
-    urls = ["https://github.com/wpilibsuite/roborio-toolchain/releases/download/v2022-1/FRC-2022-Windows64-Toolchain-7.3.0.zip"],
+#    sha256 = "3a8815d9c715e7f0f5d2106e4f16282863a3ff63121d259703b281881daea683",
+    urls = ["https://github.com/wpilibsuite/opensdk/releases/download/v2023-5/cortexa9_vfpv3-roborio-academic-2023-x86_64-w64-mingw32-Toolchain-12.1.0.zip"],
 )
 
 # Same as above for macOS (currently only supports x86_64, native support for arm64 (M1) coming soon? for now use Rosetta 2)
 http_archive(
     name = "athena_toolchain_macos_x64_files",
     build_file = "@//:build_tools/toolchain/athena_toolchain_macos_x64_files.BUILD",
-    sha256 = "47d29989d2618c0fc439b72e8d3d734b93952da4136dd05a7648af19662700b7",
-    urls = ["https://github.com/wpilibsuite/roborio-toolchain/releases/download/v2022-1/FRC-2022-Mac-Toolchain-7.3.0.tar.gz"],
+#    sha256 = "47d29989d2618c0fc439b72e8d3d734b93952da4136dd05a7648af19662700b7",
+    urls = ["https://github.com/wpilibsuite/opensdk/releases/download/v2023-5/cortexa9_vfpv3-roborio-academic-2023-x86_64-apple-darwin-Toolchain-12.1.0.tgz"],
 )
 
 # Toolchains for compiling flatbuffers (.fbs) to generated source files

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -219,7 +219,7 @@ http_archive(
 http_archive(
     name = "athena_toolchain_linux_x64_files",
     build_file = "@//:build_tools/toolchain/athena_toolchain_linux_x64_files.BUILD",
-#    sha256 = "b27cde302e46d11524aedf664129bc3ac7df02a78d0f9e4ab3f1feb40d667ab4",
+    sha256 = "56bd5b53a4149b06fd4cf675dc0596668af47ca8da72c461b7d772ada35cbdc5",
     urls = ["https://github.com/wpilibsuite/opensdk/releases/download/v2023-5/cortexa9_vfpv3-roborio-academic-2023-x86_64-linux-gnu-Toolchain-12.1.0.tgz"],
 )
 
@@ -227,7 +227,7 @@ http_archive(
 http_archive(
     name = "athena_toolchain_windows_x64_files",
     build_file = "@//:build_tools/toolchain/athena_toolchain_windows_x64_files.BUILD",
-#    sha256 = "3a8815d9c715e7f0f5d2106e4f16282863a3ff63121d259703b281881daea683",
+    sha256 = "04049728801e97fa41a8aa0837e40103c89391d0479f106aad6f959bbccd9da5",
     urls = ["https://github.com/wpilibsuite/opensdk/releases/download/v2023-5/cortexa9_vfpv3-roborio-academic-2023-x86_64-w64-mingw32-Toolchain-12.1.0.zip"],
 )
 
@@ -235,7 +235,7 @@ http_archive(
 http_archive(
     name = "athena_toolchain_macos_x64_files",
     build_file = "@//:build_tools/toolchain/athena_toolchain_macos_x64_files.BUILD",
-#    sha256 = "47d29989d2618c0fc439b72e8d3d734b93952da4136dd05a7648af19662700b7",
+    sha256 = "511a64461bfdec00bacb9abe1470f1c112fc9773b29dbb275b1dc9560b973146",
     urls = ["https://github.com/wpilibsuite/opensdk/releases/download/v2023-5/cortexa9_vfpv3-roborio-academic-2023-x86_64-apple-darwin-Toolchain-12.1.0.tgz"],
 )
 

--- a/build_tools/toolchain/athena_cc_toolchain.bzl
+++ b/build_tools/toolchain/athena_cc_toolchain.bzl
@@ -61,7 +61,7 @@ def _impl(ctx):
     tool_paths = [
         tool_path(
             name = name,
-            path = "frc2022/roborio/bin/arm-frc2022-linux-gnueabi-{}{}".format(name, exec_extension),
+            path = "roborio-academic/bin/arm-frc2023-linux-gnueabi-{}{}".format(name, exec_extension),
         )
         for name in [
             "ar",
@@ -136,15 +136,15 @@ def _impl(ctx):
         ctx = ctx,
         toolchain_identifier = "roborio_toolchain",
         host_system_name = "local",
-        target_system_name = "arm-frc2022-linux-gnueabi",
+        target_system_name = "arm-nilrt-linux-gnueabi",
         target_cpu = "armv7",
         target_libc = "glibc-2.24",
         cc_target_os = "linux",
-        compiler = "gcc-7.3.0",
-        abi_version = "gcc-7.3.0",
+        compiler = "gcc-12.1.0",
+        abi_version = "gcc-12.1.0",
         abi_libc_version = "glibc-2.24",
         tool_paths = tool_paths,
-        builtin_sysroot = "external/athena_toolchain_%s_files/frc2022/roborio/arm-frc2022-linux-gnueabi" % ctx.attr.toolchain_host,
+        builtin_sysroot = "external/athena_toolchain_%s_files/roborio-academic/arm-nilrt-linux-gnueabi/sysroot" % ctx.attr.toolchain_host,
         features = features,
     )
 

--- a/build_tools/toolchain/athena_toolchain_linux_x64_files.BUILD
+++ b/build_tools/toolchain/athena_toolchain_linux_x64_files.BUILD
@@ -2,7 +2,7 @@ load("@//build_tools/toolchain:athena_cc_toolchain.bzl", "athena_cc_toolchain_co
 
 filegroup(
     name = "toolchain-files",
-    srcs = glob(["frc2022/roborio/**/*"]),
+    srcs = glob(["roborio-academic/**/*"]),
 )
 
 athena_cc_toolchain_config(

--- a/build_tools/toolchain/athena_toolchain_macos_x64_files.BUILD
+++ b/build_tools/toolchain/athena_toolchain_macos_x64_files.BUILD
@@ -2,7 +2,7 @@ load("@//build_tools/toolchain:athena_cc_toolchain.bzl", "athena_cc_toolchain_co
 
 filegroup(
     name = "toolchain-files",
-    srcs = glob(["frc2022/roborio/**/*"]),
+    srcs = glob(["roborio-academic/**/*"]),
 )
 
 athena_cc_toolchain_config(

--- a/build_tools/toolchain/athena_toolchain_windows_x64_files.BUILD
+++ b/build_tools/toolchain/athena_toolchain_windows_x64_files.BUILD
@@ -2,7 +2,7 @@ load("@//build_tools/toolchain:athena_cc_toolchain.bzl", "athena_cc_toolchain_co
 
 filegroup(
     name = "toolchain-files",
-    srcs = glob(["frc2022/roborio/**/*"]),
+    srcs = glob(["roborio-academic/**/*"]),
 )
 
 athena_cc_toolchain_config(


### PR DESCRIPTION
This change brings in the new 2023 toolchain for building for athena/artemis. 
* GCC was bumped from 7 to 12 to support c++20. This jump means that glibc > 2.31 is required on the *host* system, meaning in the case of Ubuntu, 22.04 or higher is required to build for athena. This does not affect macOS or Windows.
* A future mitigation for this that we may want to explore is to use our hermetic clang toolchain to build for athena, and only use the WPILib provided toolchain package for the sysroot. This would potentially require some modifications to the third party dependency we are using for our clang toolchain.