### PR TITLE
Load Monitoring for RoboRIO

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/AdvantageKit.iml
+++ b/.idea/AdvantageKit.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="GradleMigrationSettings" migrationVersion="1" />
+  <component name="GradleSettings">
+    <option name="linkedExternalProjectsSettings">
+      <GradleProjectSettings>
+        <option name="externalProjectPath" value="$PROJECT_DIR$/example_projects/template" />
+        <option name="gradleJvm" value="18" />
+        <option name="modules">
+          <set>
+            <option value="$PROJECT_DIR$/example_projects/template" />
+          </set>
+        </option>
+      </GradleProjectSettings>
+      <GradleProjectSettings>
+        <option name="externalProjectPath" value="$PROJECT_DIR$/example_projects/wpilib_build_file" />
+        <option name="gradleJvm" value="18" />
+        <option name="modules">
+          <set>
+            <option value="$PROJECT_DIR$/example_projects/wpilib_build_file" />
+          </set>
+        </option>
+      </GradleProjectSettings>
+    </option>
+  </component>
+</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ExternalStorageConfigurationManager" enabled="true" />
+  <component name="FrameworkDetectionExcludesConfiguration">
+    <file type="web" url="file://$PROJECT_DIR$/example_projects/template" />
+  </component>
+  <component name="ProjectRootManager">
+    <output url="file://$PROJECT_DIR$/out" />
+  </component>
+</project>

--- a/junction/core/src/org/littletonrobotics/junction/LoadMonitor.java
+++ b/junction/core/src/org/littletonrobotics/junction/LoadMonitor.java
@@ -1,0 +1,244 @@
+package org.littletonrobotics.junction;
+
+import edu.wpi.first.wpilibj.RobotBase;
+import org.littletonrobotics.junction.inputs.LoggedSystemStats;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+
+// Based on work done by Teams 254 & 1736 in the casserole RioLoadMonitor
+
+public class LoadMonitor {
+    public static LoadMonitor getInstance() {
+        if (instance == null) {
+            instance = new LoadMonitor();
+        }
+        return instance;
+    }
+    public static LoadMonitor instance;
+    private static final Logger logger = Logger.getInstance();
+
+    private final LoggedSystemStats.SystemStatsInputs sysInputs = new LoggedSystemStats.SystemStatsInputs();
+    /** Rate of update of the load variables in milliseconds. 1s should be enough? */
+    public static final int UPDATE_RATE_MS = 500;
+    /** Overall (all-cpu) load percentage (non-idle time) */
+    public double totalCPULoadPct = 0;
+    /** Memory used percentage */
+    public double totalMemUsedPct = 0;
+    /** JVM memory used percentage */
+    public double totalJVMMemUsedPct = 0;
+
+    //To ensure we only calculate load between the last measurement and this one, we must store the
+    //previous values measured from the kernel, since the kernel reports aggregate time counts
+    double prevUserTime = 0;
+    double prevNicedTime = 0;
+    double prevSystemTime = 0;
+    double prevIdleTime = 0;
+
+    //Set to true if we can't read the file (wrong os, or something else weird)
+    //Will prevent burning processor cycles if we can't actually get any info
+    boolean giveUp = false;
+
+    // These "files" contain the load info on a linux system
+    static final String CPU_LOAD_VIRT_FILE = "/proc/stat";
+    static final String MEM_LOAD_VIRT_FILE = "/proc/meminfo";
+
+    /**
+     * Constructor. Initalizes measurement system and starts a slow
+     * background thread to gather load info
+     */
+    public LoadMonitor(){
+        if(RobotBase.isSimulation()){
+            return; //nothing to do for simulation.
+        }
+
+        //Reset give up flag
+        giveUp = false;
+
+        // Kick off monitor in new thread.
+        // Thanks to Team 254 for an example of how to do this!
+        Thread monitorThread = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    while(!Thread.currentThread().isInterrupted()){
+                        periodicUpdate();
+                        Thread.sleep(UPDATE_RATE_MS);
+                    }
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+
+            }
+        });
+        //Set up thread properties and start it off
+        monitorThread.setName("Load Monitor Thread");
+        monitorThread.setPriority(Thread.MIN_PRIORITY);
+        monitorThread.start();
+    }
+
+    /**
+     * Updates the present loads based on info from the /proc virtual
+     * filesystem. Should be called in the background. This takes up
+     * some number of resources (opening and closing files), so it's
+     * worthwhile not running it too fast. will be called internally
+     * by the thread started in the constructor
+     */
+    private void periodicUpdate(){
+        String CPUTotalLoadRawLine = new String();
+        File file;
+
+        if(!giveUp){
+            //////////////////////////////////////////////////////////////////////////////
+            //// CPU LOAD PARSING & CALCULATION
+            //////////////////////////////////////////////////////////////////////////////
+            //Get meaningful line from CPU load virtual file
+            file = new File(CPU_LOAD_VIRT_FILE);
+
+            try {
+                BufferedReader br = new BufferedReader(new FileReader(file));
+                CPUTotalLoadRawLine = br.readLine();
+                while(CPUTotalLoadRawLine != null){
+                    if(CPUTotalLoadRawLine.startsWith("cpu ")){
+                        break;
+                    }
+                    CPUTotalLoadRawLine = br.readLine();
+                }
+                br.close();
+            } catch(IOException e){
+                System.out.println("WARNING: cannot get raw CPU load data. Giving up future attempts to read.");
+                e.printStackTrace();
+                giveUp = true;
+            }
+
+            //line now contains cpu load text info
+            //separated by spaces in the format:
+            // "cpu <user> <nice> <system> <idle> ..."
+            // Time units are system dependent, but we don't care
+            // since we are calculating a percentage.
+            assert CPUTotalLoadRawLine != null;
+            String[] tokens = CPUTotalLoadRawLine.split(" ");
+
+            double curUserTime = 0;
+            double curNicedTime = 0;
+            double curSystemTime = 0;
+            double curIdleTime = 0;
+            try{
+                curUserTime = Double.parseDouble(tokens[2]); //Start at 2, because RIO parses an extra empty token at 1
+                curNicedTime = Double.parseDouble(tokens[3]);
+                curSystemTime = Double.parseDouble(tokens[4]);
+                curIdleTime = Double.parseDouble(tokens[5]);
+            }catch(Exception e) {
+                System.out.println("WARNING: cannot parse CPU load. Giving up future attempts to read.");
+                e.printStackTrace();
+                giveUp = true;
+            }
+
+            //Calculate change in time counters since last measurement
+            double deltaUserTime = curUserTime - prevUserTime;
+            double deltaNicedTime = curNicedTime - prevNicedTime;
+            double deltaSystemTime = curSystemTime - prevSystemTime;
+            double deltaIdleTime = curIdleTime - prevIdleTime;
+
+            prevUserTime = curUserTime;
+            prevNicedTime = curNicedTime;
+            prevSystemTime = curSystemTime;
+            prevIdleTime = curIdleTime;
+
+            //Add up totals
+            double totalInUseTime = (deltaUserTime + deltaNicedTime + deltaSystemTime);
+            double totalTime = totalInUseTime + deltaIdleTime;
+
+            //Calculate CPU load to nearest tenth of percent
+            totalCPULoadPct = ((double)Math.round(totalInUseTime/totalTime * 1000.0))/10.0;
+
+
+
+            //////////////////////////////////////////////////////////////////////////////
+            //// MEMORY LOAD PARSING & CALCULATION
+            //////////////////////////////////////////////////////////////////////////////
+            String memTotalStr = "";
+            String memFreeStr = "";
+            String line;
+
+            //Get meaningful line from CPU load virtual file
+            file = new File(MEM_LOAD_VIRT_FILE);
+            try {
+                BufferedReader br = new BufferedReader(new FileReader(file));
+                line = br.readLine();
+                while(line != null){
+                    if(line.startsWith("MemTotal: ")){
+                        memTotalStr = line;
+                    } else if(line.startsWith("MemFree:")){
+                        memFreeStr = line;
+                        break;
+                    }
+                    line = br.readLine();
+                }
+                br.close();
+            } catch(IOException e){
+                System.out.println("WARNING: cannot get raw memory load data. Giving up future attempts to read.");
+                e.printStackTrace();
+                giveUp = true;
+            }
+
+            //Split up the string which should be in the format
+            // "<title> <value> <units>" and we only care about value.
+            String[] memTotalTokens = memTotalStr.split("\\s+");
+            String[] memFreeTokens = memFreeStr.split("\\s+");
+
+            //Parse values from proper tokens
+            double curTotalMem = 0;
+            double curFreeMem = 0;
+            try{
+                curTotalMem = Double.parseDouble(memTotalTokens[1]);
+                curFreeMem = Double.parseDouble(memFreeTokens[1]);
+            }catch(Exception e) {
+                System.out.println("WARNING: cannot parse memory load. Giving up future attempts to read.");
+                e.printStackTrace();
+                giveUp = true;
+            }
+
+            totalMemUsedPct = ((double)Math.round((1.0 - curFreeMem/curTotalMem) * 1000.0))/10.0;
+        }
+
+
+        if(giveUp){
+            //Indicate we're not getting the load values
+            totalCPULoadPct = -1;
+            totalMemUsedPct = -1;
+        }
+
+        //Grab JVM memory (outside of give-up loop)
+        double jvmTotalMem = Runtime.getRuntime().totalMemory();
+        double jvmFreeMem = Runtime.getRuntime().freeMemory();
+        totalJVMMemUsedPct = (jvmTotalMem - jvmFreeMem)/(jvmTotalMem) * 100.0;
+    }
+
+    /**
+     * Getter for load percentage on CPU. Aggregate of all cores on the system, including
+     * both system and user processes.
+     * @return percentage of non-idle time, or -1 if percentage unavailable
+     */
+    public double getCPUUtilization(){
+        return totalCPULoadPct;
+    }
+
+    /**
+     * Getter for the load percentage on memory.
+     * @return percentage of available system RAM, or -1 if percentage unavailable.
+     */
+    public double getSystemMemoryUtilization(){
+        return totalMemUsedPct;
+    }
+
+    /**
+     * Getter for the load percentage on memory in the Java Virtual Machine.
+     * @return percentage of available JVM RAM, or -1 if percentage unavailable.
+     */
+    public double getJVMMemoryUtilization(){
+        return totalJVMMemUsedPct;
+    }
+}

--- a/junction/core/src/org/littletonrobotics/junction/LoadMonitor.java
+++ b/junction/core/src/org/littletonrobotics/junction/LoadMonitor.java
@@ -1,8 +1,5 @@
 package org.littletonrobotics.junction;
 
-import edu.wpi.first.wpilibj.RobotBase;
-import org.littletonrobotics.junction.inputs.LoggedSystemStats;
-
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
@@ -11,47 +8,43 @@ import java.io.IOException;
 // Based on work done by Teams 254 & 1736 in the casserole RioLoadMonitor
 
 public class LoadMonitor {
-    public static LoadMonitor getInstance() {
-        if (instance == null) {
-            instance = new LoadMonitor();
-        }
-        return instance;
-    }
-    public static LoadMonitor instance;
-    private static final Logger logger = Logger.getInstance();
-
-    private final LoggedSystemStats.SystemStatsInputs sysInputs = new LoggedSystemStats.SystemStatsInputs();
-    /** Rate of update of the load variables in milliseconds. 1s should be enough? */
+    /**
+     * Rate of update of the load variables in milliseconds. 1s should be enough?
+     */
     public static final int UPDATE_RATE_MS = 500;
-    /** Overall (all-cpu) load percentage (non-idle time) */
+    static final String CPU_LOAD_VIRTUAL_FILE = "/proc/stat";
+    static final String MEM_LOAD_VIRTUAL_FILE = "/proc/meminfo";
+    private static final String OS = System.getProperty("os.name").toLowerCase();
+    public static LoadMonitor instance;
+    /**
+     * Overall (all-cpu) load percentage (non-idle time)
+     */
     public double totalCPULoadPct = 0;
-    /** Memory used percentage */
+    /**
+     * Memory used percentage including cached memory
+     */
     public double totalMemUsedPct = 0;
-    /** JVM memory used percentage */
+    /**
+     * JVM memory used percentage, may have discrete jumps when garbage collection occurs or jvm dedicated
+     * memory is resized.
+     */
     public double totalJVMMemUsedPct = 0;
-
-    //To ensure we only calculate load between the last measurement and this one, we must store the
-    //previous values measured from the kernel, since the kernel reports aggregate time counts
     double prevUserTime = 0;
     double prevNicedTime = 0;
     double prevSystemTime = 0;
     double prevIdleTime = 0;
 
-    //Set to true if we can't read the file (wrong os, or something else weird)
-    //Will prevent burning processor cycles if we can't actually get any info
+    // Will prevent burning processor cycles if data is unreachable
     boolean giveUp = false;
-
-    // These "files" contain the load info on a linux system
-    static final String CPU_LOAD_VIRT_FILE = "/proc/stat";
-    static final String MEM_LOAD_VIRT_FILE = "/proc/meminfo";
-
     /**
-     * Constructor. Initalizes measurement system and starts a slow
+     * Constructor. Initializes measurement system and starts a two hertz
      * background thread to gather load info
      */
-    public LoadMonitor(){
-        if(RobotBase.isSimulation()){
-            return; //nothing to do for simulation.
+    public LoadMonitor() {
+        if(!OS.contains("nix") && !OS.contains("nux") && !OS.contains("aix")){
+            System.out.println("WARNING: LoadMonitor is only supported for the RoboRIO & other linux based " +
+                    "operating systems. LoadMonitor will not be active.");
+            return; // nothing to do.
         }
 
         //Reset give up flag
@@ -59,19 +52,16 @@ public class LoadMonitor {
 
         // Kick off monitor in new thread.
         // Thanks to Team 254 for an example of how to do this!
-        Thread monitorThread = new Thread(new Runnable() {
-            @Override
-            public void run() {
-                try {
-                    while(!Thread.currentThread().isInterrupted()){
-                        periodicUpdate();
-                        Thread.sleep(UPDATE_RATE_MS);
-                    }
-                } catch (Exception e) {
-                    e.printStackTrace();
+        Thread monitorThread = new Thread(() -> {
+            try {
+                while (!Thread.currentThread().isInterrupted()) {
+                    periodicUpdate();
+                    Thread.sleep(UPDATE_RATE_MS);
                 }
-
+            } catch (Exception e) {
+                e.printStackTrace();
             }
+
         });
         //Set up thread properties and start it off
         monitorThread.setName("Load Monitor Thread");
@@ -79,45 +69,43 @@ public class LoadMonitor {
         monitorThread.start();
     }
 
+    public static LoadMonitor getInstance() {
+        if (instance == null) {
+            instance = new LoadMonitor();
+        }
+        return instance;
+    }
+
     /**
-     * Updates the present loads based on info from the /proc virtual
-     * filesystem. Should be called in the background. This takes up
-     * some number of resources (opening and closing files), so it's
-     * worthwhile not running it too fast. will be called internally
-     * by the thread started in the constructor
+     * Updates the loads based on info from the /proc virtual
+     * filesystem. Should be called in the background. will be called
+     * internally by the thread started in the constructor
      */
-    private void periodicUpdate(){
-        String CPUTotalLoadRawLine = new String();
+    private void periodicUpdate() {
+        String CPUTotalLoadRawLine = "";
         File file;
 
-        if(!giveUp){
-            //////////////////////////////////////////////////////////////////////////////
-            //// CPU LOAD PARSING & CALCULATION
-            //////////////////////////////////////////////////////////////////////////////
-            //Get meaningful line from CPU load virtual file
-            file = new File(CPU_LOAD_VIRT_FILE);
+        if (!giveUp) {
+            // CPU load parsing
+            // Get meaningful line from CPU load virtual file
+            file = new File(CPU_LOAD_VIRTUAL_FILE);
 
             try {
                 BufferedReader br = new BufferedReader(new FileReader(file));
                 CPUTotalLoadRawLine = br.readLine();
-                while(CPUTotalLoadRawLine != null){
-                    if(CPUTotalLoadRawLine.startsWith("cpu ")){
+                while (CPUTotalLoadRawLine != null) {
+                    if (CPUTotalLoadRawLine.startsWith("cpu ")) {
                         break;
                     }
                     CPUTotalLoadRawLine = br.readLine();
                 }
                 br.close();
-            } catch(IOException e){
+            } catch (IOException e) {
                 System.out.println("WARNING: cannot get raw CPU load data. Giving up future attempts to read.");
                 e.printStackTrace();
                 giveUp = true;
             }
 
-            //line now contains cpu load text info
-            //separated by spaces in the format:
-            // "cpu <user> <nice> <system> <idle> ..."
-            // Time units are system dependent, but we don't care
-            // since we are calculating a percentage.
             assert CPUTotalLoadRawLine != null;
             String[] tokens = CPUTotalLoadRawLine.split(" ");
 
@@ -125,18 +113,18 @@ public class LoadMonitor {
             double curNicedTime = 0;
             double curSystemTime = 0;
             double curIdleTime = 0;
-            try{
+            try {
                 curUserTime = Double.parseDouble(tokens[2]); //Start at 2, because RIO parses an extra empty token at 1
                 curNicedTime = Double.parseDouble(tokens[3]);
                 curSystemTime = Double.parseDouble(tokens[4]);
                 curIdleTime = Double.parseDouble(tokens[5]);
-            }catch(Exception e) {
+            } catch (Exception e) {
                 System.out.println("WARNING: cannot parse CPU load. Giving up future attempts to read.");
                 e.printStackTrace();
                 giveUp = true;
             }
 
-            //Calculate change in time counters since last measurement
+            // Calculate change in time counters since last measurement
             double deltaUserTime = curUserTime - prevUserTime;
             double deltaNicedTime = curNicedTime - prevNicedTime;
             double deltaSystemTime = curSystemTime - prevSystemTime;
@@ -147,98 +135,87 @@ public class LoadMonitor {
             prevSystemTime = curSystemTime;
             prevIdleTime = curIdleTime;
 
-            //Add up totals
+            // Add up totals
             double totalInUseTime = (deltaUserTime + deltaNicedTime + deltaSystemTime);
             double totalTime = totalInUseTime + deltaIdleTime;
 
-            //Calculate CPU load to nearest tenth of percent
-            totalCPULoadPct = ((double)Math.round(totalInUseTime/totalTime * 1000.0))/10.0;
+            // Calculate CPU load to nearest tenth of percent
+            totalCPULoadPct = ((double) Math.round(totalInUseTime / totalTime * 1000.0)) / 10.0;
 
-
-
-            //////////////////////////////////////////////////////////////////////////////
-            //// MEMORY LOAD PARSING & CALCULATION
-            //////////////////////////////////////////////////////////////////////////////
+            // Memory parsing and calculation
             String memTotalStr = "";
             String memFreeStr = "";
             String line;
 
-            //Get meaningful line from CPU load virtual file
-            file = new File(MEM_LOAD_VIRT_FILE);
+            // Get meaningful line from CPU load virtual file
+            file = new File(MEM_LOAD_VIRTUAL_FILE);
             try {
                 BufferedReader br = new BufferedReader(new FileReader(file));
                 line = br.readLine();
-                while(line != null){
-                    if(line.startsWith("MemTotal: ")){
+                while (line != null) {
+                    if (line.startsWith("MemTotal: ")) {
                         memTotalStr = line;
-                    } else if(line.startsWith("MemFree:")){
+                    } else if (line.startsWith("MemFree:")) {
                         memFreeStr = line;
                         break;
                     }
                     line = br.readLine();
                 }
                 br.close();
-            } catch(IOException e){
+            } catch (IOException e) {
                 System.out.println("WARNING: cannot get raw memory load data. Giving up future attempts to read.");
                 e.printStackTrace();
                 giveUp = true;
             }
 
-            //Split up the string which should be in the format
-            // "<title> <value> <units>" and we only care about value.
             String[] memTotalTokens = memTotalStr.split("\\s+");
             String[] memFreeTokens = memFreeStr.split("\\s+");
 
-            //Parse values from proper tokens
+            // Parse values from proper tokens
             double curTotalMem = 0;
             double curFreeMem = 0;
-            try{
+            try {
                 curTotalMem = Double.parseDouble(memTotalTokens[1]);
                 curFreeMem = Double.parseDouble(memFreeTokens[1]);
-            }catch(Exception e) {
+            } catch (Exception e) {
                 System.out.println("WARNING: cannot parse memory load. Giving up future attempts to read.");
                 e.printStackTrace();
                 giveUp = true;
             }
 
-            totalMemUsedPct = ((double)Math.round((1.0 - curFreeMem/curTotalMem) * 1000.0))/10.0;
+            totalMemUsedPct = ((double) Math.round((1.0 - curFreeMem / curTotalMem) * 1000.0)) / 10.0;
         }
-
-
-        if(giveUp){
-            //Indicate we're not getting the load values
-            totalCPULoadPct = -1;
-            totalMemUsedPct = -1;
-        }
-
-        //Grab JVM memory (outside of give-up loop)
+        // Grab JVM memory (outside give-up loop)
         double jvmTotalMem = Runtime.getRuntime().totalMemory();
         double jvmFreeMem = Runtime.getRuntime().freeMemory();
-        totalJVMMemUsedPct = (jvmTotalMem - jvmFreeMem)/(jvmTotalMem) * 100.0;
+        totalJVMMemUsedPct = (jvmTotalMem - jvmFreeMem) / (jvmTotalMem) * 100.0;
     }
 
     /**
      * Getter for load percentage on CPU. Aggregate of all cores on the system, including
      * both system and user processes.
-     * @return percentage of non-idle time, or -1 if percentage unavailable
+     *
+     * @return percentage of non-idle time, or 0 if percentage unavailable
      */
-    public double getCPUUtilization(){
+    public double getCPUUtilization() {
         return totalCPULoadPct;
     }
 
     /**
-     * Getter for the load percentage on memory.
-     * @return percentage of available system RAM, or -1 if percentage unavailable.
+     * Getter for the load percentage on memory. Total memory utilization includes cached memory.
+     *
+     * @return percentage of available system RAM, or 0 if percentage unavailable.
      */
-    public double getSystemMemoryUtilization(){
+    public double getSystemMemoryUtilization() {
         return totalMemUsedPct;
     }
 
     /**
      * Getter for the load percentage on memory in the Java Virtual Machine.
-     * @return percentage of available JVM RAM, or -1 if percentage unavailable.
+     *
+     * @return percentage of available JVM RAM, or 0 if percentage unavailable.
      */
-    public double getJVMMemoryUtilization(){
+    public double getJVMMemoryUtilization() {
         return totalJVMMemUsedPct;
     }
 }

--- a/junction/core/src/org/littletonrobotics/junction/LoadMonitor.java
+++ b/junction/core/src/org/littletonrobotics/junction/LoadMonitor.java
@@ -42,9 +42,9 @@ public class LoadMonitor {
      */
     public LoadMonitor() {
         if(!OS.contains("nix") && !OS.contains("nux") && !OS.contains("aix")){
-            System.out.println("WARNING: LoadMonitor is only supported for the RoboRIO & other linux based " +
+            System.out.println("Advantage Kit LoadMonitor is only supported for the RoboRIO & other linux based " +
                     "operating systems. LoadMonitor will not be active.");
-            return; // nothing to do.
+            return;
         }
 
         //Reset give up flag

--- a/junction/core/src/org/littletonrobotics/junction/inputs/LoggedSystemStats.java
+++ b/junction/core/src/org/littletonrobotics/junction/inputs/LoggedSystemStats.java
@@ -46,9 +46,9 @@ public class LoggedSystemStats {
     public boolean systemActive;
     public CANStatus canStatus = new CANStatus();
     public long epochTime;
-    public double cpuUtilization;
-    public double memoryUtilization;
-    public double jvmMemoryUtilization;
+    public double cpuUtilizationPercent;
+    public double memoryUtilizationPercent;
+    public double jvmMemoryUtilizationPercent;
 
     @Override
     public void toLog(LogTable table) {
@@ -80,9 +80,9 @@ public class LoggedSystemStats {
       table.put("CANBus/TransmitErrorCount", canStatus.transmitErrorCount);
       table.put("EpochTimeMicros", epochTime);
 
-      table.put("Load/CPU", cpuUtilization);
-      table.put("Load/SystemMemoryUsage", memoryUtilization);
-      table.put("Load/JVMMemoryUsage", jvmMemoryUtilization);
+      table.put("LoadMonitor/CPUUsagePercent", cpuUtilizationPercent);
+      table.put("LoadMonitor/SystemMemoryUsagePercent", memoryUtilizationPercent);
+      table.put("LoadMonitor/JVMMemoryUsagePercent", jvmMemoryUtilizationPercent);
     }
 
     @Override
@@ -116,9 +116,9 @@ public class LoggedSystemStats {
           (int) table.getInteger("CANBus/TransmitErrorCount", canStatus.transmitErrorCount));
       epochTime = table.getInteger("EpochTimeMicros", epochTime);
 
-      cpuUtilization = table.getDouble("Load/CPU", cpuUtilization);
-      memoryUtilization = table.getDouble("Load/SystemMemoryUsage", memoryUtilization);
-      jvmMemoryUtilization = table.getDouble("Load/JVMMemoryUsage", jvmMemoryUtilization);
+      cpuUtilizationPercent = table.getDouble("LoadMonitor/CPUUsagePercent", cpuUtilizationPercent);
+      memoryUtilizationPercent = table.getDouble("LoadMonitor/SystemMemoryUsagePercent", memoryUtilizationPercent);
+      jvmMemoryUtilizationPercent = table.getDouble("LoadMonitor/JVMMemoryUsagePercent", jvmMemoryUtilizationPercent);
     }
   }
 
@@ -155,9 +155,9 @@ public class LoggedSystemStats {
           (int) conduit.getTransmitErrorCount());
       sysInputs.epochTime = conduit.getEpochTime();
 
-      sysInputs.cpuUtilization = LoadMonitor.getInstance().getCPUUtilization();
-      sysInputs.memoryUtilization = LoadMonitor.getInstance().getSystemMemoryUtilization();
-      sysInputs.jvmMemoryUtilization = LoadMonitor.getInstance().getJVMMemoryUtilization();
+      sysInputs.cpuUtilizationPercent = LoadMonitor.getInstance().getCPUUtilization();
+      sysInputs.memoryUtilizationPercent = LoadMonitor.getInstance().getSystemMemoryUtilization();
+      sysInputs.jvmMemoryUtilizationPercent = LoadMonitor.getInstance().getJVMMemoryUtilization();
     }
 
     logger.processInputs("SystemStats", sysInputs);

--- a/junction/core/src/org/littletonrobotics/junction/inputs/LoggedSystemStats.java
+++ b/junction/core/src/org/littletonrobotics/junction/inputs/LoggedSystemStats.java
@@ -1,6 +1,7 @@
 package org.littletonrobotics.junction.inputs;
 
 import org.littletonrobotics.conduit.ConduitApi;
+import org.littletonrobotics.junction.LoadMonitor;
 import org.littletonrobotics.junction.LogTable;
 import org.littletonrobotics.junction.Logger;
 
@@ -45,6 +46,9 @@ public class LoggedSystemStats {
     public boolean systemActive;
     public CANStatus canStatus = new CANStatus();
     public long epochTime;
+    public double cpuUtilization;
+    public double memoryUtilization;
+    public double jvmMemoryUtilization;
 
     @Override
     public void toLog(LogTable table) {
@@ -75,6 +79,10 @@ public class LoggedSystemStats {
       table.put("CANBus/ReceiveErrorCount", canStatus.receiveErrorCount);
       table.put("CANBus/TransmitErrorCount", canStatus.transmitErrorCount);
       table.put("EpochTimeMicros", epochTime);
+
+      table.put("Load/CPU", cpuUtilization);
+      table.put("Load/SystemMemoryUsage", memoryUtilization);
+      table.put("Load/JVMMemoryUsage", jvmMemoryUtilization);
     }
 
     @Override
@@ -107,6 +115,10 @@ public class LoggedSystemStats {
           (int) table.getInteger("CANBus/ReceiveErrorCount", canStatus.receiveErrorCount),
           (int) table.getInteger("CANBus/TransmitErrorCount", canStatus.transmitErrorCount));
       epochTime = table.getInteger("EpochTimeMicros", epochTime);
+
+      cpuUtilization = table.getDouble("Load/CPU", cpuUtilization);
+      memoryUtilization = table.getDouble("Load/SystemMemoryUsage", memoryUtilization);
+      jvmMemoryUtilization = table.getDouble("Load/JVMMemoryUsage", jvmMemoryUtilization);
     }
   }
 
@@ -142,6 +154,10 @@ public class LoggedSystemStats {
           (int) conduit.getReceiveErrorCount(),
           (int) conduit.getTransmitErrorCount());
       sysInputs.epochTime = conduit.getEpochTime();
+
+      sysInputs.cpuUtilization = LoadMonitor.getInstance().getCPUUtilization();
+      sysInputs.memoryUtilization = LoadMonitor.getInstance().getSystemMemoryUtilization();
+      sysInputs.jvmMemoryUtilization = LoadMonitor.getInstance().getJVMMemoryUtilization();
     }
 
     logger.processInputs("SystemStats", sysInputs);


### PR DESCRIPTION
Load monitor for the robo RIO, accurately logs JVM memory usage as a percent, Free memory as a percent, & aggregate CPU usage as a percent every half second to avoid overusing the Rio's limited resources.

![image](https://user-images.githubusercontent.com/62668093/232638293-3c7507d3-4ef9-4137-a7c7-a74ddcaaab4c.png)

## Notes 
- the jagged drop on JVM memory usage is correct it's just garbage cleaning & jvm heap resizing
- functions on any linux OS as it relies on the /proc virtual files.
- reported memory usage includes cached memory

