### PR TITLE
Add support for serialization marker interfaces

### DIFF
--- a/junction/core/src/org/littletonrobotics/junction/LogTable.java
+++ b/junction/core/src/org/littletonrobotics/junction/LogTable.java
@@ -35,6 +35,8 @@ import edu.wpi.first.util.protobuf.Protobuf;
 import edu.wpi.first.util.protobuf.ProtobufBuffer;
 import edu.wpi.first.util.struct.StructBuffer;
 import edu.wpi.first.util.struct.Struct;
+import edu.wpi.first.util.struct.StructSerializable;
+import edu.wpi.first.util.WPISerializable;
 import edu.wpi.first.wpilibj.DriverStation;
 import us.hebi.quickbuf.ProtoMessage;
 
@@ -438,7 +440,7 @@ public class LogTable {
    * exists as a different type.
    */
   @SuppressWarnings("unchecked")
-  public <T> void put(String key, T value) {
+  public <T extends WPISerializable> void put(String key, T value) {
     // If struct is supported, write as struct
     Struct<T> struct = (Struct<T>) findStructType(value.getClass());
     if (struct != null) {
@@ -457,17 +459,17 @@ public class LogTable {
 
   /**
    * Writes a new auto serialized array value to the table. Skipped if the key
-   * already
-   * exists as a different type.
+   * already exists as a different type.
    */
   @SuppressWarnings("unchecked")
-  public <T> void put(String key, T... value) {
+  public <T extends StructSerializable> void put(String key, T... value) {
     // If struct is supported, write as struct
     Struct<T> struct = (Struct<T>) findStructType(value.getClass().getComponentType());
     if (struct != null) {
       put(key, struct, value);
     } else {
-      DriverStation.reportError("Auto serialization is not supported for type " + value.getClass().getSimpleName(),
+      DriverStation.reportError(
+          "Auto serialization is not supported for array type " + value.getClass().getComponentType().getSimpleName(),
           false);
     }
   }
@@ -804,7 +806,7 @@ public class LogTable {
 
   /** Reads a serialized (struct/protobuf) value from the table. */
   @SuppressWarnings("unchecked")
-  public <T> T get(String key, T defaultValue) {
+  public <T extends WPISerializable> T get(String key, T defaultValue) {
     if (data.containsKey(prefix + key)) {
       String typeString = data.get(prefix + key).customTypeStr;
       if (typeString.startsWith("struct:")) {
@@ -825,7 +827,7 @@ public class LogTable {
 
   /** Reads a serialized (struct) array value from the table. */
   @SuppressWarnings("unchecked")
-  public <T> T[] get(String key, T... defaultValue) {
+  public <T extends StructSerializable> T[] get(String key, T... defaultValue) {
     if (data.containsKey(prefix + key)) {
       String typeString = data.get(prefix + key).customTypeStr;
       if (typeString.startsWith("struct:")) {

--- a/junction/core/src/org/littletonrobotics/junction/Logger.java
+++ b/junction/core/src/org/littletonrobotics/junction/Logger.java
@@ -51,6 +51,8 @@ import edu.wpi.first.units.Measure;
 import edu.wpi.first.units.Unit;
 import edu.wpi.first.util.protobuf.Protobuf;
 import edu.wpi.first.util.struct.Struct;
+import edu.wpi.first.util.struct.StructSerializable;
+import edu.wpi.first.util.WPISerializable;
 import us.hebi.quickbuf.ProtoMessage;
 
 /** Central class for recording and replaying log data. */
@@ -708,9 +710,8 @@ public class Logger {
    * simulator, use this method to record extra data based on the original inputs.
    * 
    * <p>
-   * This method serializes a single object as a struct or protobuf automatically
-   * by searching for a {@code struct} or {@code proto} field. Struct is preferred
-   * if both methods are supported.
+   * This method serializes a single object as a struct or protobuf automatically.
+   * Struct is preferred if both methods are supported.
    * 
    * @param T     The type
    * @param key   The name of the field to record. It will be stored under
@@ -718,7 +719,7 @@ public class Logger {
    * @param value The value of the field.
    */
   @SuppressWarnings("unchecked")
-  public static <T> void recordOutput(String key, T value) {
+  public static <T extends WPISerializable> void recordOutput(String key, T value) {
     if (running) {
       outputTable.put(key, value);
     }
@@ -729,9 +730,8 @@ public class Logger {
    * simulator, use this method to record extra data based on the original inputs.
    * 
    * <p>
-   * This method serializes an array of objects as a struct automatically
-   * by searching for a {@code struct} field. Top-level protobuf arrays are not
-   * supported.
+   * This method serializes an array of objects as a struct automatically.
+   * Top-level protobuf arrays are not supported.
    * 
    * @param T     The type
    * @param key   The name of the field to record. It will be stored under
@@ -739,7 +739,7 @@ public class Logger {
    * @param value The value of the field.
    */
   @SuppressWarnings("unchecked")
-  public static <T> void recordOutput(String key, T... value) {
+  public static <T extends StructSerializable> void recordOutput(String key, T... value) {
     if (running) {
       outputTable.put(key, value);
     }


### PR DESCRIPTION
Allows for compile-time checking of compatible types when using recordOutput or AutoLog (not AutoLogOutput). Builds will fail until the WPILib version is updated.