### PR TITLE
Fix LocalADStarAK in example projects

### DIFF
--- a/example_projects/advanced_swerve_drive/src/main/java/frc/robot/util/LocalADStarAK.java
+++ b/example_projects/advanced_swerve_drive/src/main/java/frc/robot/util/LocalADStarAK.java
@@ -28,7 +28,7 @@ public class LocalADStarAK implements Pathfinder {
    */
   @Override
   public boolean isNewPathAvailable() {
-    if (Logger.hasReplaySource()) {
+    if (!Logger.hasReplaySource()) {
       io.updateIsNewPathAvailable();
     }
 
@@ -46,7 +46,7 @@ public class LocalADStarAK implements Pathfinder {
    */
   @Override
   public PathPlannerPath getCurrentPath(PathConstraints constraints, GoalEndState goalEndState) {
-    if (Logger.hasReplaySource()) {
+    if (!Logger.hasReplaySource()) {
       io.updateCurrentPathPoints(constraints, goalEndState);
     }
 
@@ -67,7 +67,7 @@ public class LocalADStarAK implements Pathfinder {
    */
   @Override
   public void setStartPosition(Translation2d startPosition) {
-    if (Logger.hasReplaySource()) {
+    if (!Logger.hasReplaySource()) {
       io.adStar.setStartPosition(startPosition);
     }
   }
@@ -80,7 +80,7 @@ public class LocalADStarAK implements Pathfinder {
    */
   @Override
   public void setGoalPosition(Translation2d goalPosition) {
-    if (Logger.hasReplaySource()) {
+    if (!Logger.hasReplaySource()) {
       io.adStar.setGoalPosition(goalPosition);
     }
   }
@@ -96,7 +96,9 @@ public class LocalADStarAK implements Pathfinder {
   @Override
   public void setDynamicObstacles(
       List<Pair<Translation2d, Translation2d>> obs, Translation2d currentRobotPos) {
-    io.adStar.setDynamicObstacles(obs, currentRobotPos);
+    if (!Logger.hasReplaySource()) {
+      io.adStar.setDynamicObstacles(obs, currentRobotPos);
+    }
   }
 
   private static class ADStarIO implements LoggableInputs {
@@ -127,8 +129,7 @@ public class LocalADStarAK implements Pathfinder {
 
       List<PathPoint> pathPoints = new ArrayList<>();
       for (int i = 0; i < pointsLogged.length; i += 2) {
-        pathPoints.add(
-            new PathPoint(new Translation2d(pointsLogged[i], pointsLogged[i + 1]), null));
+        pathPoints.add(new PathPoint(new Translation2d(pointsLogged[i], pointsLogged[i + 1]), null));
       }
 
       currentPathPoints = pathPoints;

--- a/example_projects/diff_drive/src/main/java/frc/robot/util/LocalADStarAK.java
+++ b/example_projects/diff_drive/src/main/java/frc/robot/util/LocalADStarAK.java
@@ -28,7 +28,7 @@ public class LocalADStarAK implements Pathfinder {
    */
   @Override
   public boolean isNewPathAvailable() {
-    if (Logger.hasReplaySource()) {
+    if (!Logger.hasReplaySource()) {
       io.updateIsNewPathAvailable();
     }
 
@@ -46,7 +46,7 @@ public class LocalADStarAK implements Pathfinder {
    */
   @Override
   public PathPlannerPath getCurrentPath(PathConstraints constraints, GoalEndState goalEndState) {
-    if (Logger.hasReplaySource()) {
+    if (!Logger.hasReplaySource()) {
       io.updateCurrentPathPoints(constraints, goalEndState);
     }
 
@@ -67,7 +67,7 @@ public class LocalADStarAK implements Pathfinder {
    */
   @Override
   public void setStartPosition(Translation2d startPosition) {
-    if (Logger.hasReplaySource()) {
+    if (!Logger.hasReplaySource()) {
       io.adStar.setStartPosition(startPosition);
     }
   }
@@ -80,7 +80,7 @@ public class LocalADStarAK implements Pathfinder {
    */
   @Override
   public void setGoalPosition(Translation2d goalPosition) {
-    if (Logger.hasReplaySource()) {
+    if (!Logger.hasReplaySource()) {
       io.adStar.setGoalPosition(goalPosition);
     }
   }
@@ -96,7 +96,9 @@ public class LocalADStarAK implements Pathfinder {
   @Override
   public void setDynamicObstacles(
       List<Pair<Translation2d, Translation2d>> obs, Translation2d currentRobotPos) {
-    io.adStar.setDynamicObstacles(obs, currentRobotPos);
+    if (!Logger.hasReplaySource()) {
+      io.adStar.setDynamicObstacles(obs, currentRobotPos);
+    }
   }
 
   private static class ADStarIO implements LoggableInputs {
@@ -127,8 +129,7 @@ public class LocalADStarAK implements Pathfinder {
 
       List<PathPoint> pathPoints = new ArrayList<>();
       for (int i = 0; i < pointsLogged.length; i += 2) {
-        pathPoints.add(
-            new PathPoint(new Translation2d(pointsLogged[i], pointsLogged[i + 1]), null));
+        pathPoints.add(new PathPoint(new Translation2d(pointsLogged[i], pointsLogged[i + 1]), null));
       }
 
       currentPathPoints = pathPoints;

--- a/example_projects/kitbot_2024/src/main/java/frc/robot/util/LocalADStarAK.java
+++ b/example_projects/kitbot_2024/src/main/java/frc/robot/util/LocalADStarAK.java
@@ -28,7 +28,7 @@ public class LocalADStarAK implements Pathfinder {
    */
   @Override
   public boolean isNewPathAvailable() {
-    if (Logger.hasReplaySource()) {
+    if (!Logger.hasReplaySource()) {
       io.updateIsNewPathAvailable();
     }
 
@@ -46,7 +46,7 @@ public class LocalADStarAK implements Pathfinder {
    */
   @Override
   public PathPlannerPath getCurrentPath(PathConstraints constraints, GoalEndState goalEndState) {
-    if (Logger.hasReplaySource()) {
+    if (!Logger.hasReplaySource()) {
       io.updateCurrentPathPoints(constraints, goalEndState);
     }
 
@@ -67,7 +67,7 @@ public class LocalADStarAK implements Pathfinder {
    */
   @Override
   public void setStartPosition(Translation2d startPosition) {
-    if (Logger.hasReplaySource()) {
+    if (!Logger.hasReplaySource()) {
       io.adStar.setStartPosition(startPosition);
     }
   }
@@ -80,7 +80,7 @@ public class LocalADStarAK implements Pathfinder {
    */
   @Override
   public void setGoalPosition(Translation2d goalPosition) {
-    if (Logger.hasReplaySource()) {
+    if (!Logger.hasReplaySource()) {
       io.adStar.setGoalPosition(goalPosition);
     }
   }
@@ -96,7 +96,9 @@ public class LocalADStarAK implements Pathfinder {
   @Override
   public void setDynamicObstacles(
       List<Pair<Translation2d, Translation2d>> obs, Translation2d currentRobotPos) {
-    io.adStar.setDynamicObstacles(obs, currentRobotPos);
+    if (!Logger.hasReplaySource()) {
+      io.adStar.setDynamicObstacles(obs, currentRobotPos);
+    }
   }
 
   private static class ADStarIO implements LoggableInputs {
@@ -127,8 +129,7 @@ public class LocalADStarAK implements Pathfinder {
 
       List<PathPoint> pathPoints = new ArrayList<>();
       for (int i = 0; i < pointsLogged.length; i += 2) {
-        pathPoints.add(
-            new PathPoint(new Translation2d(pointsLogged[i], pointsLogged[i + 1]), null));
+        pathPoints.add(new PathPoint(new Translation2d(pointsLogged[i], pointsLogged[i + 1]), null));
       }
 
       currentPathPoints = pathPoints;

--- a/example_projects/swerve_drive/src/main/java/frc/robot/util/LocalADStarAK.java
+++ b/example_projects/swerve_drive/src/main/java/frc/robot/util/LocalADStarAK.java
@@ -28,7 +28,7 @@ public class LocalADStarAK implements Pathfinder {
    */
   @Override
   public boolean isNewPathAvailable() {
-    if (Logger.hasReplaySource()) {
+    if (!Logger.hasReplaySource()) {
       io.updateIsNewPathAvailable();
     }
 
@@ -46,7 +46,7 @@ public class LocalADStarAK implements Pathfinder {
    */
   @Override
   public PathPlannerPath getCurrentPath(PathConstraints constraints, GoalEndState goalEndState) {
-    if (Logger.hasReplaySource()) {
+    if (!Logger.hasReplaySource()) {
       io.updateCurrentPathPoints(constraints, goalEndState);
     }
 
@@ -67,7 +67,7 @@ public class LocalADStarAK implements Pathfinder {
    */
   @Override
   public void setStartPosition(Translation2d startPosition) {
-    if (Logger.hasReplaySource()) {
+    if (!Logger.hasReplaySource()) {
       io.adStar.setStartPosition(startPosition);
     }
   }
@@ -80,7 +80,7 @@ public class LocalADStarAK implements Pathfinder {
    */
   @Override
   public void setGoalPosition(Translation2d goalPosition) {
-    if (Logger.hasReplaySource()) {
+    if (!Logger.hasReplaySource()) {
       io.adStar.setGoalPosition(goalPosition);
     }
   }
@@ -96,7 +96,9 @@ public class LocalADStarAK implements Pathfinder {
   @Override
   public void setDynamicObstacles(
       List<Pair<Translation2d, Translation2d>> obs, Translation2d currentRobotPos) {
-    io.adStar.setDynamicObstacles(obs, currentRobotPos);
+    if (!Logger.hasReplaySource()) {
+      io.adStar.setDynamicObstacles(obs, currentRobotPos);
+    }
   }
 
   private static class ADStarIO implements LoggableInputs {
@@ -127,8 +129,7 @@ public class LocalADStarAK implements Pathfinder {
 
       List<PathPoint> pathPoints = new ArrayList<>();
       for (int i = 0; i < pointsLogged.length; i += 2) {
-        pathPoints.add(
-            new PathPoint(new Translation2d(pointsLogged[i], pointsLogged[i + 1]), null));
+        pathPoints.add(new PathPoint(new Translation2d(pointsLogged[i], pointsLogged[i + 1]), null));
       }
 
       currentPathPoints = pathPoints;


### PR DESCRIPTION
The LocalADStarAK implementation included in the example projects does not work since the inputs are only updated if there is a replay source instead of if there is *not* a replay source.

Updated each project to the current version published to the gist.