### PR TITLE
Reference correct motor in registerSignal call in example project

### DIFF
--- a/example_projects/advanced_swerve_drive/src/main/java/frc/robot/subsystems/drive/ModuleIOSparkMax.java
+++ b/example_projects/advanced_swerve_drive/src/main/java/frc/robot/subsystems/drive/ModuleIOSparkMax.java
@@ -133,7 +133,7 @@ public class ModuleIOSparkMax implements ModuleIO {
             .registerSignal(
                 () -> {
                   double value = turnRelativeEncoder.getPosition();
-                  if (driveSparkMax.getLastError() == REVLibError.kOk) {
+                  if (turnSparkMax.getLastError() == REVLibError.kOk) {
                     return OptionalDouble.of(value);
                   } else {
                     return OptionalDouble.empty();


### PR DESCRIPTION
Apologies if I'm wrong, but it seems there was a bit of a copy-paste error here; you're checking the error on the drive spark max but getting the value of the turning one.