### PR TITLE
Generic IO container

### DIFF
--- a/junction/core/src/org/littletonrobotics/junction/inputs/LoggableIO.java
+++ b/junction/core/src/org/littletonrobotics/junction/inputs/LoggableIO.java
@@ -1,0 +1,5 @@
+package org.littletonrobotics.junction.inputs;
+
+public interface LoggableIO<T extends LoggableInputs> {
+    void updateInputs(T inputs);
+}

--- a/junction/core/src/org/littletonrobotics/junction/inputs/LoggableSystem.java
+++ b/junction/core/src/org/littletonrobotics/junction/inputs/LoggableSystem.java
@@ -1,0 +1,38 @@
+package org.littletonrobotics.junction.inputs;
+
+import org.littletonrobotics.junction.Logger;
+
+public class LoggableSystem<T extends LoggableIO<R>, R extends LoggableInputs> {
+    private final T io;
+    private final R inputs;
+    private final String key;
+
+    public LoggableSystem(T io, R inputs) {
+        this.io = io;
+        this.inputs = inputs;
+        this.key = getClass().getSimpleName() + "Inputs";
+    }
+
+    public LoggableSystem(T io, R inputs, String key) {
+        this.io = io;
+        this.inputs = inputs;
+        this.key = key;
+    }
+
+    public void updateInputs() {
+        io.updateInputs(inputs);
+        Logger.processInputs(key, inputs);
+    }
+
+    public T getIO() {
+        return io;
+    }
+
+    public R getInputs() {
+        return inputs;
+    }
+
+    public String getKey() {
+        return key;
+    }
+}


### PR DESCRIPTION
What is this?
This pull requests will add a new method for instantiating IO/inputs in subsystems. Instead of storing the IO interface and IO Inputs in the subsystem, a parent class is used. 

Why did I do this?
1. I noticed how all IO interfaces have the `updateInputs(LoggableInputs inputs);` method and how every subsystem has to create an instance of both IO and Inputs. This can become very cluttered, especially if you have multiple IO interfaces in one subsystem. Moreover, this addition reduces the amount of code in a subsystem and increases readability.
2. I anecdotally found that this was easier for new students to create subsystems if they only had to create one object of the same type and call the same methods in every subsystem for getting the IO and inputs.

Notes:
This addition is backwards compatible and does not require existing implementations to use this method but provides another approach for teams who are interested.

Example:
```
public class Deployer extends SubsystemBase {
    private final LoggableSystem<DeployerIO, DeployerInputs> system;

    public Deployer(DeployerIO io) {
        this.system = new LoggableSystem<>(io, new DeployerInputs());
    }

    @Override
    public void periodic() {
        system.updateInputs();
    }

    public void stop() {
        system.getIO().stop();
    }

    public double getDeployerMotorSpeed() {
        return system.getInputs().deployerSpeed;
    }
}
```