### PR TITLE
Read joystick counts from UDP

### DIFF
--- a/conduit/conduit_schema.fbs
+++ b/conduit/conduit_schema.fbs
@@ -13,12 +13,12 @@ namespace org.littletonrobotics.conduit.schema;
 struct Joystick {
     name:[uint8:256];
     type:uint8;
-    axis_count:uint8;
+    axis_count:int16;
     axis_types:[uint8:12];
     axis_values:[float32:12];
     button_count:uint8;
     buttons:int32;
-    pov_count:uint8;
+    pov_count:int16;
     pov_values:[int16:12];
     is_xbox:bool;
 }

--- a/conduit/wpilibio/src/ds_reader.cc
+++ b/conduit/wpilibio/src/ds_reader.cc
@@ -68,12 +68,9 @@ void DsReader::update_ds_data() {
       std::memcpy(stick_buf->mutable_name()->Data(), jd.name,
                   stick_buf->name()->size());
       stick_buf->mutate_type(jd.type);
-      stick_buf->mutate_axis_count(jd.axisCount);
 
       std::memcpy(stick_buf->mutable_axis_types()->Data(), jd.axisTypes,
                   stick_buf->mutable_axis_types()->size() * sizeof(uint8_t));
-      stick_buf->mutate_button_count(jd.buttonCount);
-      stick_buf->mutate_pov_count(jd.povCount);
       stick_buf->mutate_is_xbox(jd.isXbox);
 
       // Read joystick values
@@ -81,15 +78,18 @@ void DsReader::update_ds_data() {
       HAL_GetJoystickAxes(joystickNum, &axes);
       std::memcpy(stick_buf->mutable_axis_values()->Data(), axes.axes,
                   stick_buf->axis_values()->size() * sizeof(float));
+      stick_buf->mutate_axis_count(axes.count);
 
       HAL_JoystickPOVs povs;
       HAL_GetJoystickPOVs(joystickNum, &povs);
       std::memcpy(stick_buf->mutable_pov_values()->Data(), povs.povs,
                   stick_buf->pov_values()->size() * sizeof(int16_t));
+      stick_buf->mutate_pov_count(povs.count);
 
       HAL_JoystickButtons buttons;
       HAL_GetJoystickButtons(joystickNum, &buttons);
       stick_buf->mutate_buttons(buttons.buttons);
+      stick_buf->mutate_button_count(buttons.count);
     }
 
     // Copy all data into the internal buffer

--- a/conduit/wpilibio/test/size_test.cc
+++ b/conduit/wpilibio/test/size_test.cc
@@ -54,7 +54,7 @@ TEST(SizeTests, JoystickSizes) {
   ASSERT_EQ(sizeof(HAL_JoystickDescriptor::type),
             sizeof(decltype(joystick.type())));
 
-  ASSERT_EQ(sizeof(HAL_JoystickDescriptor::axisCount),
+  ASSERT_EQ(sizeof(HAL_JoystickAxes::count),
             sizeof(decltype(joystick.axis_count())));
 
   ASSERT_EQ(HAL_kMaxJoystickAxes, joystick.axis_types()->size());
@@ -65,13 +65,13 @@ TEST(SizeTests, JoystickSizes) {
   ASSERT_EQ(sizeof(HAL_JoystickAxes::axes[0]),
             sizeof(decltype(joystick.axis_values()->Get(0))));
 
-  ASSERT_EQ(sizeof(HAL_JoystickDescriptor::buttonCount),
+  ASSERT_EQ(sizeof(HAL_JoystickButtons::count),
             sizeof(decltype(joystick.button_count())));
 
   ASSERT_EQ(sizeof(HAL_JoystickButtons::buttons),
             sizeof(decltype(joystick.buttons())));
 
-  ASSERT_EQ(sizeof(HAL_JoystickDescriptor::povCount),
+  ASSERT_EQ(sizeof(HAL_JoystickPOVs::count),
             sizeof(decltype(joystick.pov_count())));
 
   ASSERT_EQ(HAL_kMaxJoystickPOVs, joystick.pov_values()->size());


### PR DESCRIPTION
Fixes #91

The counts are included in the return values for `HAL_GetJoystickAxes`, `HAL_GetJoystickPOVs`, and `HAL_GetJoystickButtons`, which are read from UDP instead of UDP. For some reason the types for the axis and POV counts are different from those included in the joystick descriptor.