### PR TITLE
Convert limelight timestamp in vision example to the correct time unit

### DIFF
--- a/template_projects/vision/src/main/java/frc/robot/subsystems/vision/VisionIOLimelight.java
+++ b/template_projects/vision/src/main/java/frc/robot/subsystems/vision/VisionIOLimelight.java
@@ -84,7 +84,7 @@ public class VisionIOLimelight implements VisionIO {
       poseObservations.add(
           new PoseObservation(
               // Timestamp, based on server timestamp of publish and latency
-              rawSample.timestamp * 1.0e-9 - rawSample.value[7] * 1.0e-3,
+              rawSample.timestamp * 1.0e-6 - rawSample.value[7] * 1.0e-3,
 
               // 3D pose estimate
               parsePose(rawSample.value),
@@ -109,7 +109,7 @@ public class VisionIOLimelight implements VisionIO {
       poseObservations.add(
           new PoseObservation(
               // Timestamp, based on server timestamp of publish and latency
-              rawSample.timestamp * 1.0e-9 - rawSample.value[7] * 1.0e-3,
+              rawSample.timestamp * 1.0e-6 - rawSample.value[7] * 1.0e-3,
 
               // 3D pose estimate
               parsePose(rawSample.value),


### PR DESCRIPTION
The limelight pose observation timestamp from NT was being converted from microseconds to kiloseconds by multiplying the timestamp by `1.0e-9`. Should be fixed by multiplying by `1.0e-6`. Resolves #132 