### PR TITLE
Fix docs to refer to "Tuning" table.

### DIFF
--- a/docs/docs/data-flow/recording-inputs/dashboard-inputs.md
+++ b/docs/docs/data-flow/recording-inputs/dashboard-inputs.md
@@ -38,7 +38,7 @@ public Command getAutonomousCommand() {
 ```
 
 :::tip
-AdvantageScope supports tuning via NetworkTables when running in the AdvantageKit NetworkTables mode. Tunable values must be published to the "/Tunable" table using `LoggedNetworkNumber`, `LoggedNetworkString`, or `LoggedNetworkBoolean`. Check the [AdvantageScope docs](https://docs.advantagescope.org/getting-started/connect-live#tuning-with-advantagekit) for details.
+AdvantageScope supports tuning via NetworkTables when running in the AdvantageKit NetworkTables mode. Tunable values must be published to the "/Tuning" table using `LoggedNetworkNumber`, `LoggedNetworkString`, or `LoggedNetworkBoolean`. Check the [AdvantageScope docs](https://docs.advantagescope.org/getting-started/connect-live#tuning-with-advantagekit) for details.
 :::
 
 A `LoggedDashboardChooser` can also be constructed using an existing `SendableChooser`, which allows for compatibility PathPlanner's `AutoBuilder` API:


### PR DESCRIPTION
The AdvantageKit and AdvantageScope docs were inconsistent in terms of the NetworkTable name that is required for AdvantageScope to be able to tune values. Verified that the table name must be "Tuning".