### PR TITLE
Log Measure Objects as Serialized Structs with Unit Logging

### DIFF
--- a/akit/src/main/java/org/littletonrobotics/junction/LogTable.java
+++ b/akit/src/main/java/org/littletonrobotics/junction/LogTable.java
@@ -461,7 +461,7 @@ public class LogTable {
   public <U extends Unit> void put(String key, Measure<U> value) {
     if (value == null)
       return;
-    put(key, new LogValue(value.baseUnitMagnitude(), null));
+    put(key, new MeasureRecord(value.baseUnitMagnitude(), value.baseUnit().name()));
   }
 
   /**
@@ -1017,25 +1017,19 @@ public class LogTable {
   /** Reads a Measure value from the table. */
   @SuppressWarnings("unchecked")
   public <U extends Unit, M extends Measure<U>> M get(String key, M defaultValue) {
-    if (data.containsKey(prefix + key)) {
-      double value = get(key).getDouble(defaultValue.baseUnitMagnitude());
-      return (M) defaultValue.unit().ofBaseUnits(value);
-    } else {
-      return defaultValue;
-    }
+    MeasureRecord record = get(key, new MeasureRecord(defaultValue.baseUnitMagnitude(), defaultValue.unit().name()));
+
+    return (M) defaultValue.unit().ofBaseUnits(record.value());
   }
 
   /** Reads a MutableMeasure value from the table. */
   @SuppressWarnings("unchecked")
   public <U extends Unit, Base extends Measure<U>, M extends MutableMeasure<U, Base, M>> M get(
       String key, M defaultValue) {
-    if (data.containsKey(prefix + key)) {
-      double baseValue = get(key).getDouble(defaultValue.baseUnitMagnitude());
-      double relativeValue = defaultValue.unit().fromBaseUnits(baseValue);
-      return (M) new GenericMutableMeasureImpl<>(relativeValue, baseValue, defaultValue.unit());
-    } else {
-      return defaultValue;
-    }
+    MeasureRecord record = get(key, new MeasureRecord(defaultValue.baseUnitMagnitude(), defaultValue.unit().name()));
+    double relativeValue = defaultValue.unit().fromBaseUnits(record.value());
+
+    return (M) new GenericMutableMeasureImpl<>(relativeValue, record.value(), defaultValue.unit());
   }
 
   /** Reads a LoggableInput subtable from the table. */

--- a/akit/src/main/java/org/littletonrobotics/junction/Logger.java
+++ b/akit/src/main/java/org/littletonrobotics/junction/Logger.java
@@ -985,6 +985,25 @@ public class Logger {
    * main thread. See the "Common Issues" page in the documentation for more
    * details.
    * 
+   * @param key   The name of the field to record. It will be stored under
+   *              "/RealOutputs" or "/ReplayOutputs"
+   * @param value The value of the field.
+   */
+  public static <U extends Unit> void recordOutput(String key, Measure<U> value, U unit) {
+    if (running) {
+      outputTable.put(key, value.in(unit));
+    }
+  }
+
+  /**
+   * Records a single output field for easy access when viewing the log. On the
+   * simulator, use this method to record extra data based on the original inputs.
+   * 
+   * <p>
+   * This method is <b>not thread-safe</b> and should only be called from the
+   * main thread. See the "Common Issues" page in the documentation for more
+   * details.
+   * 
    * <p>
    * This method serializes a single object as a struct. Example usage:
    * {@code recordOutput("MyPose", Pose2d.struct, new Pose2d())}

--- a/akit/src/main/java/org/littletonrobotics/junction/MeasureRecord.java
+++ b/akit/src/main/java/org/littletonrobotics/junction/MeasureRecord.java
@@ -1,0 +1,3 @@
+package org.littletonrobotics.junction;
+
+public record MeasureRecord(double value, String unit) {}


### PR DESCRIPTION
To resolve my previous feature request on the AdvantageScope repository, this pull request attempts to log ``Measure`` objects as serialized structs rather than as their base unit. This allows the end user in AdvantageScope to easily see what unit a ``Measure`` is logged in so they can convert accordingly. This pull request also adds a convenience method to the ``Logger`` for output logging, allowing users to select which unit they would like to log ``Measure`` objects as in their outputs.

There may be errors in this code. I had trouble setting up a development environment for this codebase and do not know how to test these changes on a project.

It may make more sense to handle the serialization at a lower level instead of utilizing the record-logging functionality. I am not sure if record logging was intended more for the end user and not for internal development.