### PR TITLE
Add WPILib Color logging support

### DIFF
--- a/akit/src/main/java/org/littletonrobotics/junction/LogTable.java
+++ b/akit/src/main/java/org/littletonrobotics/junction/LogTable.java
@@ -39,6 +39,7 @@ import edu.wpi.first.util.struct.Struct;
 import edu.wpi.first.util.struct.StructSerializable;
 import edu.wpi.first.util.WPISerializable;
 import edu.wpi.first.wpilibj.DriverStation;
+import edu.wpi.first.wpilibj.util.Color;
 import us.hebi.quickbuf.ProtoMessage;
 
 /**
@@ -473,6 +474,16 @@ public class LogTable {
     if (value == null)
       return;
     put(key, new LogValue(value.baseUnitMagnitude(), null));
+  }
+
+  /**
+   * Writes a new Color value to the table. Skipped if the key already exists as
+   * a different type.
+   */
+  public void put(String key, Color value) {
+    if (value == null)
+      return;
+    put(key, value.toHexString());
   }
 
   /**
@@ -1038,6 +1049,15 @@ public class LogTable {
       double baseValue = get(key).getDouble(defaultValue.baseUnitMagnitude());
       double relativeValue = defaultValue.unit().fromBaseUnits(baseValue);
       return (M) new GenericMutableMeasureImpl<>(relativeValue, baseValue, defaultValue.unit());
+    } else {
+      return defaultValue;
+    }
+  }
+
+  /** Reads a Color value from the table. */
+  public Color get(String key, Color defaultValue) {
+    if (data.containsKey(prefix + key)) {
+      return new Color(get(key).getString(defaultValue.toHexString()));
     } else {
       return defaultValue;
     }

--- a/docs/docs/data-flow/supported-types.md
+++ b/docs/docs/data-flow/supported-types.md
@@ -47,6 +47,10 @@ Record logging can take an extended period (>100ms) the first time that a value 
 
 WPILib includes a [units library](https://docs.wpilib.org/en/latest/docs/software/basic-programming/java-units.html) that can be used to simplify unit conversions. `Measure` objects can be logged and replayed by AdvantageKit. These values will be stored in the log as doubles using the [base unit](https://github.com/wpilibsuite/allwpilib/blob/main/wpiunits/src/main/java/edu/wpi/first/units/BaseUnits.java) for the measurement type (e.g. distances will always be logged in meters).
 
+### Colors
+
+WPILib includes a [color library](https://github.wpilib.org/allwpilib/docs/release/java/edu/wpi/first/wpilibj/util/Color.html) that can be used to simplify color operations. These values will be stored in the log as a string formatted in [Hex Triplet](https://en.wikipedia.org/wiki/Web_colors) color notation.
+
 ### Enums
 
 [Enum](https://www.w3schools.com/java/java_enums.asp) values can be logged and replayed by AdvantageKit. These values will be stored in the log as string values (using the [`name()`](https://docs.oracle.com/javase/8/docs/api/java/lang/Enum.html#name--) method).


### PR DESCRIPTION
I tried to log a color from a color sensor and found that AdvantageKit has no capability to record the WPILIB color class. 

I currently log the color as a hex string (ex. #FFFFFF) using the "Color.toString" method, but there are a couple of other options (mentioned below) I'm not quite sure what's best. 
Also, I plan on someday maybe adding this as a thing in AdvantageScope that would display a changing color box (I'm not very experienced in UI programming so it'll be a bit).

The way I see it we have 3 potential options:

1. Hex string, log the color as a string "#xxxxxx" this is the most human readable.
2. Array of Ints, RGB
3. A packed 32-bit integer, using the WPILIB Colors packing method, most space-efficient but least human readable. Would also require any log processing applications to implement an unpacking method.

It's super fast to swap in any of these methods, so if there are any preferences I'll make that change ASAP.

Sidenote, I used the "tohexstring" method instead of the "toString" method because when using any of the standard colors, the toString method will return the name of the color (ex. Color.kFirstBlue.toString() will return "kFirstBlue"). This is a little unfortunate because there is a performance benefit to using .toString, as the WPILIB Color class caches/memoizes a small operation that needs to be done to generate the hex string.