### PR TITLE
Add Observable pattern to Network Inputs

### DIFF
--- a/akit/src/main/java/org/littletonrobotics/junction/networktables/LoggedDashboardChooser.java
+++ b/akit/src/main/java/org/littletonrobotics/junction/networktables/LoggedDashboardChooser.java
@@ -13,21 +13,20 @@
 
 package org.littletonrobotics.junction.networktables;
 
+import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import java.lang.reflect.Field;
 import java.util.HashMap;
 import java.util.Map;
-
 import org.littletonrobotics.junction.LogTable;
 import org.littletonrobotics.junction.Logger;
 import org.littletonrobotics.junction.inputs.LoggableInputs;
-
-import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
-import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 
 /**
  * Manages a chooser value published to the "SmartDashboard" table of NT.
  */
 public class LoggedDashboardChooser<V> extends LoggedNetworkInput {
+
   private final String key;
   private String selectedValue = null;
   private SendableChooser<String> sendableChooser = new SendableChooser<>();
@@ -70,30 +69,34 @@ public class LoggedDashboardChooser<V> extends LoggedNetworkInput {
   @SuppressWarnings("unchecked")
   public LoggedDashboardChooser(String key, SendableChooser<V> chooser) {
     this(key);
-
     // Get options map
     Map<String, V> options = new HashMap<>();
     try {
       Field mapField = SendableChooser.class.getDeclaredField("m_map");
       mapField.setAccessible(true);
       options = (Map<String, V>) mapField.get(chooser);
-    } catch (NoSuchFieldException
-        | SecurityException
-        | IllegalArgumentException
-        | IllegalAccessException e) {
+    } catch (
+      NoSuchFieldException
+      | SecurityException
+      | IllegalArgumentException
+      | IllegalAccessException e
+    ) {
       e.printStackTrace();
     }
 
     // Get default option
     String defaultString = "";
     try {
-      Field defaultField = SendableChooser.class.getDeclaredField("m_defaultChoice");
+      Field defaultField =
+        SendableChooser.class.getDeclaredField("m_defaultChoice");
       defaultField.setAccessible(true);
       defaultString = (String) defaultField.get(chooser);
-    } catch (NoSuchFieldException
-        | SecurityException
-        | IllegalArgumentException
-        | IllegalAccessException e) {
+    } catch (
+      NoSuchFieldException
+      | SecurityException
+      | IllegalArgumentException
+      | IllegalAccessException e
+    ) {
       e.printStackTrace();
     }
 

--- a/akit/src/main/java/org/littletonrobotics/junction/networktables/LoggedNetworkNumber.java
+++ b/akit/src/main/java/org/littletonrobotics/junction/networktables/LoggedNetworkNumber.java
@@ -15,15 +15,20 @@ package org.littletonrobotics.junction.networktables;
 
 import edu.wpi.first.networktables.DoubleEntry;
 import edu.wpi.first.networktables.NetworkTableInstance;
+import edu.wpi.first.networktables.PubSubOption;
+import edu.wpi.first.wpilibj.DriverStation;
 import org.littletonrobotics.junction.LogTable;
 import org.littletonrobotics.junction.Logger;
 import org.littletonrobotics.junction.inputs.LoggableInputs;
 
 /** Manages a number value published to the root table of NT. */
-public class LoggedNetworkNumber extends LoggedNetworkInput {
+public class LoggedNetworkNumber extends ObservableLoggedNetworkInput<Double> {
+
+  private static final double DEFAULT_VALUE = 0.0;
+
   private final String key;
   private final DoubleEntry entry;
-  private double defaultValue = 0.0;
+  private double defaultValue = DEFAULT_VALUE;
   private double value;
 
   /**
@@ -34,8 +39,15 @@ public class LoggedNetworkNumber extends LoggedNetworkInput {
    *            "/DashboardInputs/{key}" when logged.
    */
   public LoggedNetworkNumber(String key) {
+    super(DEFAULT_VALUE);
     this.key = key;
-    this.entry = NetworkTableInstance.getDefault().getDoubleTopic(key).getEntry(0.0);
+    this.entry = NetworkTableInstance.getDefault()
+      .getDoubleTopic(key)
+      .getEntry(
+        DEFAULT_VALUE,
+        PubSubOption.keepDuplicates(false),
+        PubSubOption.pollStorage(1)
+      );
     this.value = defaultValue;
     Logger.registerDashboardInput(this);
   }
@@ -69,7 +81,7 @@ public class LoggedNetworkNumber extends LoggedNetworkInput {
   }
 
   /** Returns the current value. */
-  public double get() {
+  public Double get() {
     return value;
   }
 
@@ -86,6 +98,14 @@ public class LoggedNetworkNumber extends LoggedNetworkInput {
   public void periodic() {
     if (!Logger.hasReplaySource()) {
       value = entry.get(defaultValue);
+
+      // Only do tunables when not in a match
+      if (DriverStation.getMatchType() == DriverStation.MatchType.None) {
+        var changes = entry.readQueueValues();
+        if (changes.length == 1) {
+          notifyListeners();
+        }
+      }
     }
     Logger.processInputs(prefix, inputs);
   }

--- a/akit/src/main/java/org/littletonrobotics/junction/networktables/ObservableLoggedNetworkInput.java
+++ b/akit/src/main/java/org/littletonrobotics/junction/networktables/ObservableLoggedNetworkInput.java
@@ -1,0 +1,81 @@
+// Copyright 2021-2025 FRC 6328
+// http://github.com/Mechanical-Advantage
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// version 3 as published by the Free Software Foundation or
+// available in the root directory of this project.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+package org.littletonrobotics.junction.networktables;
+
+import edu.wpi.first.wpilibj.DriverStation;
+import java.lang.ref.WeakReference;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.function.Consumer;
+
+public abstract class ObservableLoggedNetworkInput<T>
+    extends LoggedNetworkInput {
+
+    public static final String prefix = "NetworkInputs";
+    private final T defaultValue;
+    private final List<WeakReference<Consumer<T>>> listeners;
+
+    protected ObservableLoggedNetworkInput(T defaultValue) {
+        this.defaultValue = defaultValue;
+        this.listeners = new ArrayList<>();
+    }
+
+    public abstract T get();
+
+    /** Removes the leading slash from a key. */
+    protected static String removeSlash(String key) {
+        if (key.startsWith("/")) {
+            return key.substring(1);
+        } else {
+            return key;
+        }
+    }
+
+    public void addListener(Consumer<T> listener) {
+        listeners.add(new WeakReference<>(listener));
+
+        // Only do tunables when not in a match, when in a match, give listener the
+        // default value
+        if (DriverStation.getMatchType() == DriverStation.MatchType.None) {
+            listener.accept(get());
+        } else {
+            listener.accept(defaultValue);
+        }
+    }
+
+    public void removeListener(Consumer<T> listener) {
+        Iterator<WeakReference<Consumer<T>>> iter = listeners.iterator();
+        while (iter.hasNext()) {
+            WeakReference<Consumer<T>> ref = iter.next();
+            Consumer<T> current = ref.get();
+            if (current == null || current == listener) {
+                iter.remove();
+            }
+        }
+    }
+
+    protected void notifyListeners() {
+        Iterator<WeakReference<Consumer<T>>> iter = listeners.iterator();
+        while (iter.hasNext()) {
+            WeakReference<Consumer<T>> ref = iter.next();
+            Consumer<T> listener = ref.get();
+            if (listener != null) {
+                listener.accept(get());
+            } else {
+                iter.remove();
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR draft extends the LoggedNetworkInputs ABC with an Observable pattern:
* Modifies the concrete Network Input classes to implement the observable pattern
* Uses weak references for listeners
* Reads NT4 change queue to notify listeners in the periodic loop

This is a modification of an extension that my team is using this season (via a wrapper class):
- My team is listening to the changes to Network Inputs during testing to tune gains
- We don't want accidental changes (although unlikely) to affect practice or comp matches, so it's set to only notify listeners if the match type is None, otherwise just provides the default value.

Due to some limitations of my understanding of AKit, I don't know if the notifying of listeners only should happen in the NOT replay source case (see periodic of concrete classes) or in all cases.

I'm also not certain if extending the LoggedNetworkInputs ABC is ideal, I originally modified LoggedNetworkInputs, but was confused while conforming LoggedDashboardChooser so went this route instead.

I thought I'd offer this to AKit because I'm sure other teams may find this useful. Let me know if you have/request any changes or want some explanation of reasonings.
