### PR TITLE
Add option to force using WPISerializable in AutoLogOutput

### DIFF
--- a/akit/src/main/java/org/littletonrobotics/junction/AutoLogOutput.java
+++ b/akit/src/main/java/org/littletonrobotics/junction/AutoLogOutput.java
@@ -27,4 +27,11 @@ public @interface AutoLogOutput {
    * @return The value of the key parameter.
    */
   public String key() default "";
+
+  /**
+   * Whether or not to force the Logger to use a serialized data method.
+   *
+   * @return Whether or not to force the Logger to use a serialized data method.
+   */
+  public boolean forceSerializable() default false;
 }

--- a/akit/src/main/java/org/littletonrobotics/junction/AutoLogOutputManager.java
+++ b/akit/src/main/java/org/littletonrobotics/junction/AutoLogOutputManager.java
@@ -330,6 +330,7 @@ public class AutoLogOutputManager {
                     false);
               }
           });
+      return;
     }
 
     if (!type.isArray()) {

--- a/akit/src/main/java/org/littletonrobotics/junction/AutoLogOutputManager.java
+++ b/akit/src/main/java/org/littletonrobotics/junction/AutoLogOutputManager.java
@@ -118,6 +118,8 @@ public class AutoLogOutputManager {
                 // Get key
                 String keyParameter = method.getAnnotation(AutoLogOutput.class).key();
                 String key = makeKey(keyParameter, method.getName(), declaringClass, root);
+                boolean forceSerializable =
+                    method.getAnnotation(AutoLogOutput.class).forceSerializable();
 
                 // Register method
                 registerField(
@@ -132,7 +134,8 @@ public class AutoLogOutputManager {
                         e.printStackTrace();
                         return null;
                       }
-                    });
+                    },
+                    forceSerializable);
               }
             });
 
@@ -149,6 +152,8 @@ public class AutoLogOutputManager {
                 // Get key
                 String keyParameter = field.getAnnotation(AutoLogOutput.class).key();
                 String key = makeKey(keyParameter, field.getName(), declaringClass, root);
+                boolean forceSerializable =
+                    field.getAnnotation(AutoLogOutput.class).forceSerializable();
 
                 // Register field
                 registerField(
@@ -161,7 +166,8 @@ public class AutoLogOutputManager {
                         e.printStackTrace();
                         return null;
                       }
-                    });
+                    },
+                    forceSerializable);
                 return;
               }
 
@@ -308,7 +314,24 @@ public class AutoLogOutputManager {
    * @param type The type of object being logged.
    * @param supplier A supplier for the field values.
    */
-  private static void registerField(String key, Class<?> type, Supplier<?> supplier) {
+  private static void registerField(
+      String key, Class<?> type, Supplier<?> supplier, boolean forceSerializable) {
+    if (forceSerializable) {
+      callbacks.add(
+          () -> {
+            Object value = supplier.get();
+            if (value != null)
+              try {
+                Logger.recordOutput(key, (WPISerializable) value);
+              } catch (ClassCastException e) {
+                DriverStation.reportError(
+                    "[AdvantageKit] Auto serialization is not supported for type "
+                        + type.getSimpleName(),
+                    false);
+              }
+          });
+    }
+
     if (!type.isArray()) {
       // Single types
       if (type.equals(boolean.class)) {

--- a/docs/docs/data-flow/recording-outputs/annotation-logging.md
+++ b/docs/docs/data-flow/recording-outputs/annotation-logging.md
@@ -31,6 +31,30 @@ public class SwerveModule {
 }
 ```
 
+The `forceSerializable` parameter can be used to force the use of struct or Protobuf serialization for enum types, as shown in the example below. The class should inherit from [`StructSerializable`](https://github.wpilib.org/allwpilib/docs/release/java/edu/wpi/first/util/struct/StructSerializable.html), [`ProtobufSerializable`](https://github.wpilib.org/allwpilib/docs/release/java/edu/wpi/first/util/protobuf/ProtobufSerializable.html), or [`WPISerializable`](https://github.wpilib.org/allwpilib/docs/release/java/edu/wpi/first/util/WPISerializable.html).
+
+```java
+enum CustomEnum implements StructSerializable {
+    A(...),
+    B(...);
+
+    public final double value;
+    public static final Struct<ElevatorSetpoints> struct = ...;
+
+    Setpoint(double value) {
+        this.value = value;
+    }
+}
+
+@AutoLogOutput
+CustomEnum setpoint = CustomEnum.A; // Logs as an enum
+
+@AutoLogOutput(forceSerializable = true)
+CustomEnum setpoint = CustomEnum.A; // Logs as a struct
+```
+
+## Global Configuration
+
 By default, the parent class where `@AutoLogOutput` is used must be within the same package as `Robot` (or a subpackage). The following method can be called in the constructor of `Robot` to allow additional packages, such as a "lib" package outside of normal robot code:
 
 ```java


### PR DESCRIPTION
Resolves https://github.com/Mechanical-Advantage/AdvantageKit/issues/206

Takes a slightly different implementation approach than suggested there due to technical limitations of Java annotation processors.