### PR TITLE
Add Logger.recordOutput for Colors

### DIFF
--- a/akit/src/main/java/org/littletonrobotics/junction/Logger.java
+++ b/akit/src/main/java/org/littletonrobotics/junction/Logger.java
@@ -17,7 +17,6 @@ import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.RobotBase;
 import edu.wpi.first.wpilibj.RobotController;
 import edu.wpi.first.wpilibj.util.Color;
-
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.HashMap;


### PR DESCRIPTION
The previous PR added put(Color) and get(Color) to work as an input. But a method to add an entry into Logger.recordOutput to allow for logging Colors as outputs would be useful.