### PR TITLE
Fix typo in receiverQueueCapacity variable name

### DIFF
--- a/akit/src/main/java/org/littletonrobotics/junction/Logger.java
+++ b/akit/src/main/java/org/littletonrobotics/junction/Logger.java
@@ -38,7 +38,7 @@ import us.hebi.quickbuf.ProtoMessage;
 
 /** Central class for recording and replaying log data. */
 public class Logger {
-  private static final int receiverQueueCapcity = 500; // 10s at 50Hz
+  private static final int receiverQueueCapacity = 500; // 10s at 50Hz
 
   private static boolean running = false;
   private static long cycleCount = 0;
@@ -53,7 +53,7 @@ public class Logger {
 
   private static LogReplaySource replaySource;
   private static final BlockingQueue<LogTable> receiverQueue =
-      new ArrayBlockingQueue<LogTable>(receiverQueueCapcity);
+      new ArrayBlockingQueue<LogTable>(receiverQueueCapacity);
   private static final ReceiverThread receiverThread = new ReceiverThread(receiverQueue);
   private static boolean receiverQueueFault = false;
 


### PR DESCRIPTION
This pull request corrects a typo in the `Logger` class by fixing the spelling of the `receiverQueueCapacity` constant and updating its usage throughout the file. This change improves code readability and prevents potential confusion.

* Code cleanup:
  * Renamed the constant `receiverQueueCapcity` to `receiverQueueCapacity` and updated all references to use the corrected name in `Logger.java`. [[1]](diffhunk://#diff-6fccf4a8867b7d6b8f5c0754830dd82e13e439ba9497a8e164948de52d2c579eL41-R41) [[2]](diffhunk://#diff-6fccf4a8867b7d6b8f5c0754830dd82e13e439ba9497a8e164948de52d2c579eL56-R56)