### PR TITLE
fix improper wpilog metadata updating on unit string modification

### DIFF
--- a/akit/src/main/java/org/littletonrobotics/junction/wpilog/WPILOGWriter.java
+++ b/akit/src/main/java/org/littletonrobotics/junction/wpilog/WPILOGWriter.java
@@ -319,7 +319,10 @@ public class WPILOGWriter implements LogDataReceiver {
 
         // Check if unit changed
         if (unit != null && !unit.equals(entryUnits.get(field.getKey()))) {
-          log.setMetadata(id, unit, table.getTimestamp());
+          log.setMetadata(
+              id,
+              WPILOGConstants.entryMetadataUnits.replace("$UNITSTR", unit),
+              table.getTimestamp());
           entryUnits.put(field.getKey(), unit);
         }
 


### PR DESCRIPTION
In the `WPILOGWriter` class, when the unit on a logged value has changed, the metadata entry is replaced with the raw unit, instead of keeping consistent with initialization with a JSON-formatted entry metadata.

This pull request fixes this issue.