### PR TITLE
``LoggedPowerDistribution`` should be public

### DIFF
--- a/akit/src/main/java/org/littletonrobotics/junction/LoggedPowerDistribution.java
+++ b/akit/src/main/java/org/littletonrobotics/junction/LoggedPowerDistribution.java
@@ -30,6 +30,12 @@ public class LoggedPowerDistribution {
     ConduitApi.getInstance().configurePowerDistribution(moduleID, this.moduleType);
   }
 
+  /**
+   * Returns the singleton instance of the power distribution logger, configuring it for the default
+   * module type and ID.
+   *
+   * @return The singleton LoggedPowerDistribution instance.
+   */
   public static LoggedPowerDistribution getInstance() {
     if (instance == null) {
       instance = new LoggedPowerDistribution();
@@ -37,6 +43,14 @@ public class LoggedPowerDistribution {
     return instance;
   }
 
+  /**
+   * Returns the singleton instance of the power distribution logger, configuring it for the
+   * specified module type and ID.
+   *
+   * @param moduleID The CAN ID of the power distribution module.
+   * @param moduleType The type of the power distribution module.
+   * @return The singleton LoggedPowerDistribution instance.
+   */
   public static LoggedPowerDistribution getInstance(
       int moduleID, PowerDistribution.ModuleType moduleType) {
     if (instance == null) {


### PR DESCRIPTION
Fixes #243 .

When this module was moved from `junction.inputs` to `junction` sometime between `v4.1.2` and `v26.0.0-beta-1`, the ``public`` modifier for the `LoggedPowerDistribution` class was dropped accidentally.  This commit restores the modifier so that `LoggedPowerDistribution` can be accessible outside the ``junction`` package.