### PR TITLE
Fix issues with RLOGServer 

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,5 @@
+{
+  "name": "Java 17 Codespace",
+  "image": "mcr.microsoft.com/devcontainers/java:17",
+  "features": {}
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,0 @@
-{
-  "name": "Java 17 Codespace",
-  "image": "mcr.microsoft.com/devcontainers/java:17",
-  "features": {}
-}

--- a/akit/src/main/java/org/littletonrobotics/junction/rlog/RLOGServer.java
+++ b/akit/src/main/java/org/littletonrobotics/junction/rlog/RLOGServer.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Littleton Robotics
+// Copyright (c) 2021-2025 Littleton Robotics
 // http://github.com/Mechanical-Advantage
 //
 // Use of this source code is governed by a BSD

--- a/akit/src/main/java/org/littletonrobotics/junction/rlog/RLOGServer.java
+++ b/akit/src/main/java/org/littletonrobotics/junction/rlog/RLOGServer.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2025 Littleton Robotics
+// Copyright (c) 2021-2026 Littleton Robotics
 // http://github.com/Mechanical-Advantage
 //
 // Use of this source code is governed by a BSD
@@ -20,7 +20,7 @@ import org.littletonrobotics.junction.LogDataReceiver;
 import org.littletonrobotics.junction.LogTable;
 
 /** Sends log data over a socket connection using the RLOG format. */
-public class RLOGServer implements LogDataReceiver {
+public class RLOGServer implements LogDataReceiver, AutoCloseable {
   private final int port;
   private ServerThread thread;
   private RLOGEncoder encoder = new RLOGEncoder();
@@ -49,6 +49,11 @@ public class RLOGServer implements LogDataReceiver {
   }
 
   public void end() {
+    close();
+  }
+
+  @Override
+  public void close() {
     if (thread != null) {
       thread.close();
       thread = null;
@@ -75,7 +80,7 @@ public class RLOGServer implements LogDataReceiver {
     return fullData;
   }
 
-  private class ServerThread extends Thread {
+  private class ServerThread extends Thread implements AutoCloseable {
     private static final double heartbeatTimeoutSecs =
         3.0; // Close connection if heartbeat not received for this
     // length
@@ -195,6 +200,7 @@ public class RLOGServer implements LogDataReceiver {
               + socket.getInetAddress().getHostAddress());
     }
 
+    @Override
     public void close() {
       if (server != null) {
         try {


### PR DESCRIPTION
This pull request updates the `RLOGServer` class to improve resource management by implementing the `AutoCloseable` interface, ensuring that server threads and resources can be properly closed. It also updates the copyright year.
resolves #190 

**Resource management improvements:**

* `RLOGServer` now implements `AutoCloseable`, allowing it to be used in try-with-resources statements and ensuring proper cleanup of resources. The `end()` method now delegates to the new `close()` method. (`akit/src/main/java/org/littletonrobotics/junction/rlog/RLOGServer.java`) [[1]](diffhunk://#diff-9eef14fa47964174c11d947804075c884cb65a0e71f57c7e689b226b0b92a40bL23-R23) [[2]](diffhunk://#diff-9eef14fa47964174c11d947804075c884cb65a0e71f57c7e689b226b0b92a40bR52-R56)
* The inner `ServerThread` class also implements `AutoCloseable`, providing a `close()` method for thread resource management. (`akit/src/main/java/org/littletonrobotics/junction/rlog/RLOGServer.java`) [[1]](diffhunk://#diff-9eef14fa47964174c11d947804075c884cb65a0e71f57c7e689b226b0b92a40bL78-R83) [[2]](diffhunk://#diff-9eef14fa47964174c11d947804075c884cb65a0e71f57c7e689b226b0b92a40bR203)

**Other changes:**

* Updated the copyright year in `RLOGServer.java`. (`akit/src/main/java/org/littletonrobotics/junction/rlog/RLOGServer.java`)