### PR TITLE
add generated annotation to autologged classes

### DIFF
--- a/akit/autolog/src/main/java/org/littletonrobotics/junction/AutoLogAnnotationProcessor.java
+++ b/akit/autolog/src/main/java/org/littletonrobotics/junction/AutoLogAnnotationProcessor.java
@@ -160,8 +160,14 @@ public class AutoLogAnnotationProcessor extends AbstractProcessor {
 
               cloneBuilder.addCode("return copy;\n");
 
+              AnnotationSpec generated =
+                  AnnotationSpec.builder(ClassName.get("javax.annotation.processing", "Generated"))
+                      .addMember("value", "$S", AutoLogAnnotationProcessor.class.getCanonicalName())
+                      .build();
+
               TypeSpec type =
                   TypeSpec.classBuilder(autologgedClassName)
+                      .addAnnotation(generated)
                       .addModifiers(Modifier.PUBLIC)
                       .addSuperinterface(LOGGABLE_INPUTS_TYPE)
                       .addSuperinterface(ClassName.get("java.lang", "Cloneable"))


### PR DESCRIPTION
add the `javax.annotation.processing.Generated` annotation to generated classes.