### PR TITLE
WPILOGWriter: stop logging gracefully when disk is full to prevent robot loop overruns

### DIFF
--- a/akit/src/main/java/org/littletonrobotics/junction/wpilog/WPILOGWriter.java
+++ b/akit/src/main/java/org/littletonrobotics/junction/wpilog/WPILOGWriter.java
@@ -8,6 +8,8 @@
 package org.littletonrobotics.junction.wpilog;
 
 import edu.wpi.first.util.datalog.DataLogWriter;
+import edu.wpi.first.wpilibj.Alert;
+import edu.wpi.first.wpilibj.Alert.AlertType;
 import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.DriverStation.MatchType;
 import edu.wpi.first.wpilibj.RobotBase;
@@ -40,6 +42,12 @@ public class WPILOGWriter implements LogDataReceiver {
       DateTimeFormatter.ofPattern("yy-MM-dd_HH-mm-ss");
   private static final String advantageScopeFileName = "ascope-log-path.txt";
 
+  // Free space thresholds
+  private static final long LOW_SPACE_WARNING_BYTES = 1024L * 1024 * 1024; // 1 GB — warn
+  private static final long MIN_FREE_SPACE_BYTES = 50L * 1024 * 1024; // 50 MB — stop logging
+  // Check free space every N cycles (~10 seconds at 50Hz)
+  private static final int FREE_SPACE_CHECK_CYCLES = 500;
+
   private String folder;
   private String filename;
   private final String randomIdentifier;
@@ -51,6 +59,11 @@ public class WPILOGWriter implements LogDataReceiver {
 
   private DataLogWriter log;
   private boolean isOpen = false;
+  private int cycleCount = 0;
+  private final Alert lowSpaceAlert =
+      new Alert("[AdvantageKit] Low disk space — logging may stop mid-match.", AlertType.kWarning);
+  private final Alert diskFullAlert =
+      new Alert("[AdvantageKit] Disk full — logging stopped to prevent robot loop overruns.", AlertType.kError);
   private final AdvantageScopeOpenBehavior openBehavior;
   private LogTable lastTable;
   private int timestampID;
@@ -140,6 +153,15 @@ public class WPILOGWriter implements LogDataReceiver {
       logFile.delete();
     }
 
+    // Check free space before opening the log
+    long freeSpace = new File(folder).getFreeSpace();
+    if (freeSpace < MIN_FREE_SPACE_BYTES) {
+      diskFullAlert.set(true);
+      return;
+    } else if (freeSpace < LOW_SPACE_WARNING_BYTES) {
+      lowSpaceAlert.set(true);
+    }
+
     // Create new log
     String logPath = Path.of(folder, filename).toString();
     System.out.println("[AdvantageKit] Logging to \"" + logPath + "\"");
@@ -164,6 +186,7 @@ public class WPILOGWriter implements LogDataReceiver {
   }
 
   public void end() {
+    if (!isOpen) return;
     log.close();
 
     // Send log path to AdvantageScope
@@ -196,6 +219,20 @@ public class WPILOGWriter implements LogDataReceiver {
   public void putTable(LogTable table) {
     // Exit if log not open
     if (!isOpen) return;
+
+    // Periodically check free disk space; stop logging rather than stalling the robot loop
+    if (++cycleCount >= FREE_SPACE_CHECK_CYCLES) {
+      cycleCount = 0;
+      long freeSpace = new File(folder).getFreeSpace();
+      if (freeSpace < MIN_FREE_SPACE_BYTES) {
+        diskFullAlert.set(true);
+        log.close();
+        isOpen = false;
+        return;
+      } else if (freeSpace < LOW_SPACE_WARNING_BYTES) {
+        lowSpaceAlert.set(true);
+      }
+    }
 
     // Auto rename
     if (autoRename) {

--- a/akit/src/main/java/org/littletonrobotics/junction/wpilog/WPILOGWriter.java
+++ b/akit/src/main/java/org/littletonrobotics/junction/wpilog/WPILOGWriter.java
@@ -155,7 +155,9 @@ public class WPILOGWriter implements LogDataReceiver {
       logFile.delete();
     }
 
-    // Check free space before opening the log
+    // Reset alerts from any previous run, then recompute based on current free space
+    lowSpaceAlert.set(false);
+    diskFullAlert.set(false);
     long freeSpace = new File(folder).getFreeSpace();
     if (freeSpace < MIN_FREE_SPACE_BYTES) {
       diskFullAlert.set(true);
@@ -233,6 +235,8 @@ public class WPILOGWriter implements LogDataReceiver {
         return;
       } else if (freeSpace < LOW_SPACE_WARNING_BYTES) {
         lowSpaceAlert.set(true);
+      } else {
+        lowSpaceAlert.set(false);
       }
     }
 

--- a/akit/src/main/java/org/littletonrobotics/junction/wpilog/WPILOGWriter.java
+++ b/akit/src/main/java/org/littletonrobotics/junction/wpilog/WPILOGWriter.java
@@ -63,7 +63,9 @@ public class WPILOGWriter implements LogDataReceiver {
   private final Alert lowSpaceAlert =
       new Alert("[AdvantageKit] Low disk space — logging may stop mid-match.", AlertType.kWarning);
   private final Alert diskFullAlert =
-      new Alert("[AdvantageKit] Disk full — logging stopped to prevent robot loop overruns.", AlertType.kError);
+      new Alert(
+          "[AdvantageKit] Disk full — logging stopped to prevent robot loop overruns.",
+          AlertType.kError);
   private final AdvantageScopeOpenBehavior openBehavior;
   private LogTable lastTable;
   private int timestampID;

--- a/docs/docs/getting-started/installation/existing-projects.md
+++ b/docs/docs/getting-started/installation/existing-projects.md
@@ -60,4 +60,8 @@ Logger.start(); // Start logging! No more data receivers, replay sources, or met
 By default, the `WPILOGWriter` class writes to a USB stick when running on the roboRIO. **A FAT32 formatted USB stick must be connected to one of the roboRIO USB ports**.
 :::
 
+:::warning
+`WPILOGWriter` monitors available disk space to protect robot loop timing. If free space drops below **1 GB**, a persistent dashboard warning is raised. If free space drops below **50 MB**, logging stops immediately and a dashboard error is raised — this is preferable to allowing disk I/O to stall the 20ms robot loop. **Clear old logs from `/U/logs` regularly**, especially before events.
+:::
+
 This setup enters replay mode for all simulator runs. If you need to run the simulator without replay (e.g. a physics simulator or Romi), extra constants or selection logic is required. See the template projects for one method of implementing this logic.

--- a/docs/docs/getting-started/installation/vscode-welcome.md
+++ b/docs/docs/getting-started/installation/vscode-welcome.md
@@ -67,6 +67,10 @@ Logger.start(); // Start logging! No more data receivers, replay sources, or met
 By default, the `WPILOGWriter` class writes to a USB stick when running on the roboRIO. **A FAT32 formatted USB stick must be connected to one of the roboRIO USB ports**.
 :::
 
+:::warning
+`WPILOGWriter` monitors available disk space to protect robot loop timing. If free space drops below **1 GB**, a persistent dashboard warning is raised. If free space drops below **50 MB**, logging stops immediately and a dashboard error is raised — this is preferable to allowing disk I/O to stall the 20ms robot loop. **Clear old logs from `/U/logs` regularly**, especially before events.
+:::
+
 This setup enters replay mode for all simulator runs. If you need to run the simulator without replay (e.g. a physics simulator or Romi), extra constants or selection logic is required. See the template projects for one method of implementing this logic.
 
 :::note


### PR DESCRIPTION
## Summary

Fixes #259

When log storage fills up, synchronous `flush()` calls in `putTable()` can block the main robot loop, causing erratic mechanism behavior mid-match (e.g. mechanisms barely responding, commands not executing). This was observed in competition when a USB drive filled up and write errors caused the logger's queue to back up and stall the 20ms robot loop.

- At startup, reset any stale alerts from a prior run, then check free space:
  - < 50 MB: raise a persistent `kError` Alert and abort logging entirely
  - < 1 GB: raise a persistent `kWarning` Alert but continue logging
- Every ~10 seconds during operation (`putTable()`), recheck free space with the same thresholds; on < 50 MB, close the log and set `isOpen = false` so the existing guard short-circuits all future calls without blocking on I/O
- Clear `lowSpaceAlert` in the periodic check if space rises back above 1 GB
- Guard `end()` against calling `log.close()` if the log was already closed by the disk-full path
- Add `:::warning` admonition to `existing-projects.md` and `vscode-welcome.md` documenting the thresholds and advising teams to clear logs regularly

## Test plan

- [ ] Build passes (`./gradlew :akit:compileJava`)
- [ ] Spotless passes (`./gradlew spotlessCheck`)
- [ ] Tested locally via `publishToMavenLocal` and consumed in a robot project running in simulation
- [ ] Verified warning Alert fires when free space is below 1 GB at startup
- [ ] Verified error Alert fires and logging stops cleanly when free space is below 50 MB
- [ ] Verified no NPE in `end()` when logging was stopped early by the disk-full path

🤖 Generated with [Claude Code](https://claude.com/claude-code)