### PR TITLE
Added autolog support for mutable (Mut___) types that are not Mutable

### DIFF
--- a/akit/autolog/src/main/java/org/littletonrobotics/junction/AutoLogAnnotationProcessor.java
+++ b/akit/autolog/src/main/java/org/littletonrobotics/junction/AutoLogAnnotationProcessor.java
@@ -141,7 +141,11 @@ public class AutoLogAnnotationProcessor extends AbstractProcessor {
                           } else if (fieldElement
                               .asType()
                               .toString()
-                              .startsWith("edu.wpi.first.units.MutableMeasure")) {
+                              .startsWith("edu.wpi.first.units.MutableMeasure") 
+                              || fieldElement
+                                .asType()
+                                .toString()
+                                .startsWith("edu.wpi.first.units.measure.Mut")) {
                             // Need to clone mutable measure
                             cloneBuilder.addCode(
                                 "copy.$L = this.$L.mutableCopy();\n", simpleName, simpleName);


### PR DESCRIPTION
Fixed @AutoLog not making mutable copies of classes such as MutAngle in the clone() method.