### PR TITLE
Reduce GC churn on phoenix odometry thread

### DIFF
--- a/template_projects/sources/talonfx_swerve/src/main/java/frc/robot/subsystems/drive/PhoenixOdometryThread.java
+++ b/template_projects/sources/talonfx_swerve/src/main/java/frc/robot/subsystems/drive/PhoenixOdometryThread.java
@@ -31,7 +31,7 @@ import java.util.function.DoubleSupplier;
 public class PhoenixOdometryThread extends Thread {
   private final Lock signalsLock =
       new ReentrantLock(); // Prevents conflicts when registering signals
-  private BaseStatusSignal[] phoenixSignals = new BaseStatusSignal[0];
+  private ArrayList<BaseStatusSignal> phoenixSignals = new ArrayList<>();
   private final List<DoubleSupplier> genericSignals = new ArrayList<>();
   private final List<Queue<Double>> phoenixQueues = new ArrayList<>();
   private final List<Queue<Double>> genericQueues = new ArrayList<>();
@@ -65,10 +65,7 @@ public class PhoenixOdometryThread extends Thread {
     signalsLock.lock();
     Drive.odometryLock.lock();
     try {
-      BaseStatusSignal[] newSignals = new BaseStatusSignal[phoenixSignals.length + 1];
-      System.arraycopy(phoenixSignals, 0, newSignals, 0, phoenixSignals.length);
-      newSignals[phoenixSignals.length] = signal;
-      phoenixSignals = newSignals;
+      phoenixSignals.add(signal);
       phoenixQueues.add(queue);
     } finally {
       signalsLock.unlock();
@@ -110,14 +107,14 @@ public class PhoenixOdometryThread extends Thread {
       // Wait for updates from all signals
       signalsLock.lock();
       try {
-        if (isCANFD && phoenixSignals.length > 0) {
+        if (isCANFD && phoenixSignals.size() > 0) {
           BaseStatusSignal.waitForAll(2.0 / Drive.ODOMETRY_FREQUENCY, phoenixSignals);
         } else {
           // "waitForAll" does not support blocking on multiple signals with a bus
           // that is not CAN FD, regardless of Pro licensing. No reasoning for this
           // behavior is provided by the documentation.
           Thread.sleep((long) (1000.0 / Drive.ODOMETRY_FREQUENCY));
-          if (phoenixSignals.length > 0) BaseStatusSignal.refreshAll(phoenixSignals);
+          if (phoenixSignals.size() > 0) BaseStatusSignal.refreshAll(phoenixSignals);
         }
       } catch (InterruptedException e) {
         e.printStackTrace();
@@ -136,13 +133,13 @@ public class PhoenixOdometryThread extends Thread {
         for (BaseStatusSignal signal : phoenixSignals) {
           totalLatency += signal.getTimestamp().getLatency();
         }
-        if (phoenixSignals.length > 0) {
-          timestamp -= totalLatency / phoenixSignals.length;
+        if (phoenixSignals.size() > 0) {
+          timestamp -= totalLatency / phoenixSignals.size();
         }
 
         // Add new samples to queues
-        for (int i = 0; i < phoenixSignals.length; i++) {
-          phoenixQueues.get(i).offer(phoenixSignals[i].getValueAsDouble());
+        for (int i = 0; i < phoenixSignals.size(); i++) {
+          phoenixQueues.get(i).offer(phoenixSignals.get(i).getValueAsDouble());
         }
         for (int i = 0; i < genericSignals.size(); i++) {
           genericQueues.get(i).offer(genericSignals.get(i).getAsDouble());

--- a/template_projects/sources/talonfx_swerve/src/main/java/frc/robot/subsystems/drive/PhoenixOdometryThread.java
+++ b/template_projects/sources/talonfx_swerve/src/main/java/frc/robot/subsystems/drive/PhoenixOdometryThread.java
@@ -31,7 +31,7 @@ import java.util.function.DoubleSupplier;
 public class PhoenixOdometryThread extends Thread {
   private final Lock signalsLock =
       new ReentrantLock(); // Prevents conflicts when registering signals
-  private ArrayList<BaseStatusSignal> phoenixSignals = new ArrayList<>();
+  private final List<BaseStatusSignal> phoenixSignals = new ArrayList<>();
   private final List<DoubleSupplier> genericSignals = new ArrayList<>();
   private final List<Queue<Double>> phoenixQueues = new ArrayList<>();
   private final List<Queue<Double>> genericQueues = new ArrayList<>();


### PR DESCRIPTION
Per decompiled Phoenix source, the function `BaseStatusSignal.waitForAll` and `.refreshAll` both will call `Arrays.asList` which allocates a wrapper `ArrayList` for passing to the underlying library. Declaring as an `ArrayList` to begin with avoids this extra allocation.

It also simplifies the code a bit to rely on the API of ArrayList instead of implementing appending manually.