### PR TITLE
Ignore warning from gcc, fixing Linux builds.

### DIFF
--- a/akit/native.gradle
+++ b/akit/native.gradle
@@ -36,6 +36,8 @@ model {
             if (it.targetPlatform.operatingSystem.macOsX) {
                 it.cppCompiler.args "-Wno-unknown-warning-option"
                 it.cppCompiler.args "-Wno-character-conversion"
+            } else if (it.targetPlatform.operatingSystem.linux) {
+                it.cppCompiler.args "-Wno-maybe-uninitialized"
             }
         }
     }


### PR DESCRIPTION
It seems that in newer versions of gcc, ```SmallVector``` is flagged with a warning, supposedly due to a compiler bug, although I don't have much information. This leaves Linux users unable to build AdvantageKit, as package managers usually just let you install the latest version of gcc.

The CI action uses an LTS version of Ubuntu, which I believe is just before this becomes an issue.

The workaround I had to use to get it to build was to add a compiler option to ignore this warning on Linux.

https://github.com/pytorch/pytorch/issues/143338

https://stackoverflow.com/questions/59994518/why-does-gcc-gives-me-maybe-uninitialized-warning-for-dequeinsert-with-a-filte

```
compiling pdp_reader.cc failed.
In file included from /home/lia/.gradle/caches/9.4.1/transforms/275581871a8260db186fea6f5406af7b/transformed/wpiutil-cpp-2027.0.0-alpha-6-headers/wpi/util/SmallString.hpp:17,
                 from /home/lia/.gradle/caches/9.4.1/transforms/275581871a8260db186fea6f5406af7b/transformed/wpiutil-cpp-2027.0.0-alpha-6-headers/wpi/util/jni_util.hpp:19,
                 from /home/lia/Robotics/Repos/AdvantageKit/akit/src/main/native/cc/pdp_reader.cc:21:
/home/lia/.gradle/caches/9.4.1/transforms/275581871a8260db186fea6f5406af7b/transformed/wpiutil-cpp-2027.0.0-alpha-6-headers/wpi/util/SmallVector.hpp: In constructor ‘wpi::util::SmallVectorTemplateCommon<T, <template-parameter-1-2> >::SmallVectorTemplateCommon(size_t) [with T = char; <template-parameter-1-2> = void]’:
/home/lia/.gradle/caches/9.4.1/transforms/275581871a8260db186fea6f5406af7b/transformed/wpiutil-cpp-2027.0.0-alpha-6-headers/wpi/util/SmallVector.hpp:137:67: error: ‘<unknown>’ may be used uninitialized [-Werror=maybe-uninitialized]
  137 |   SmallVectorTemplateCommon(size_t Size) : Base(getFirstEl(), Size) {}
      |                                                                   ^
/home/lia/.gradle/caches/9.4.1/transforms/275581871a8260db186fea6f5406af7b/transformed/wpiutil-cpp-2027.0.0-alpha-6-headers/wpi/util/SmallVector.hpp:130:9: note: by argument 1 of type ‘const wpi::util::SmallVectorTemplateCommon<char, void>*’ to ‘void* wpi::util::SmallVectorTemplateCommon<T, <template-parameter-1-2> >::getFirstEl() const [with T = char; <template-parameter-1-2> = void]’ declared here
  130 |   void *getFirstEl() const {
      |         ^~~~~~~~~~
cc1plus: all warnings being treated as errors
```