### PR TITLE
Add links to the release page in the template docs

### DIFF
--- a/docs/docs/getting-started/template-projects/diff-drive-template.md
+++ b/docs/docs/getting-started/template-projects/diff-drive-template.md
@@ -23,7 +23,7 @@ The AdvantageKit differential drive template is **open-source** and **fully cust
 
 ## Setup {#setup}
 
-1. Download the differential drive template project from the AdvantageKit release on GitHub and open it in VSCode.
+1. Download the differential drive template project from the [AdvantageKit release](https://github.com/Mechanical-Advantage/AdvantageKit/releases) on GitHub and open it in VSCode.
 
 2. Click the WPILib icon in the VSCode toolbar and find the task `WPILib: Set Team Number`. Enter your team number and press enter.
 

--- a/docs/docs/getting-started/template-projects/kitbot-template.md
+++ b/docs/docs/getting-started/template-projects/kitbot-template.md
@@ -17,7 +17,7 @@ The AdvantageKit 2026 KitBot template is **open-source** and **fully customizabl
 
 ## Setup {#setup}
 
-1. Download the 2026 KitBot template project from the AdvantageKit release on GitHub and open it in VSCode.
+1. Download the 2026 KitBot template project from the [AdvantageKit release](https://github.com/Mechanical-Advantage/AdvantageKit/releases) on GitHub and open it in VSCode.
 
 2. Set up the drive subsystem using the instructions found [here](./diff-drive-template.md#setup).
 

--- a/docs/docs/getting-started/template-projects/spark-swerve-template.md
+++ b/docs/docs/getting-started/template-projects/spark-swerve-template.md
@@ -32,7 +32,7 @@ The AdvantageKit swerve templates are **open-source** and **fully customizable**
 The swerve project folder includes a predefined AdvantageScope layout with tabs for each setup and tuning step described below. To open it, click `File` > `Import Layout...` in the tab bar of AdvantageScope and select the file `AdvantageScope Swerve Calibration.json` in the swerve project folder.
 :::
 
-1. Download the Spark swerve template project from the AdvantageKit release on GitHub and open it in VSCode.
+1. Download the Spark swerve template project from the [AdvantageKit release](https://github.com/Mechanical-Advantage/AdvantageKit/releases) on GitHub and open it in VSCode.
 
 2. Click the WPILib icon in the VSCode toolbar and find the task `WPILib: Set Team Number`. Enter your team number and press enter.
 

--- a/docs/docs/getting-started/template-projects/talonfx-swerve-template.md
+++ b/docs/docs/getting-started/template-projects/talonfx-swerve-template.md
@@ -44,7 +44,7 @@ The swerve project folder includes a predefined AdvantageScope layout with tabs 
 CTRE only permits the swerve project generator to be used on swerve robots with **exclusively CTRE hardware** (including a Pigeon 2). Otherwise, switch to the "Manual" tab for standard setup instructions.
 :::
 
-1. Download the TalonFX swerve template project from the AdvantageKit release on GitHub and open it in VSCode.
+1. Download the TalonFX swerve template project from the [AdvantageKit release](https://github.com/Mechanical-Advantage/AdvantageKit/releases) on GitHub and open it in VSCode.
 
 2. Click the WPILib icon in the VSCode toolbar and find the task `WPILib: Set Team Number`. Enter your team number and press enter.
 
@@ -69,7 +69,7 @@ The project is configured to save log files when running on a real robot. **A FA
 </TabItem>
 <TabItem value="manual" label="Manual" default>
 
-1. Download the TalonFX swerve template project from the AdvantageKit release on GitHub and open it in VSCode.
+1. Download the TalonFX swerve template project from the [AdvantageKit release](https://github.com/Mechanical-Advantage/AdvantageKit/releases) on GitHub and open it in VSCode.
 
 2. Click the WPILib icon in the VSCode toolbar and find the task `WPILib: Set Team Number`. Enter your team number and press enter.
 


### PR DESCRIPTION
Simple quality-of-life change so the step-by-step instructions on the template pages in the docs link to the template downloads.

I only added links where the releases page was already directly referenced.